### PR TITLE
Added a changlog (and rolled version back to 0.0.1 until first release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+This file keeps track of all notable changes to jobbergate-api-fastapi
+
+## Unreleased
+* Added support for auth via Armasec & Auth0
+* Added unit tests
+* Migrated model definitions from legacy ``jobbergate-api``
+* Migrated endpoint definitions from legacy ``jobbergate-api``
+* Created FastAPI application and added basic routes
+* Added support for database migrations via Alembic
+* Added Makefile with targets to install, test, migrate, run, and clean
+* Added CI workflow for github action to test PRs
+* Added basic documentation in README
+* Created project with poetry for dependency and project management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 name = "jobbergateapi2"
 description = "jobbergate-api"
 license = "MIT"
-version = "0.1.0"
+version = "0.0.1"
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
#### What
Added a CHANGELOG.

Also pinned project version to 0.0.1 until first release. This will allow us to import the release script from jobbergate-cli and have the first proper release be versioned 0.1.0

#### Why
We needed a CHANGELOG

`Task`: https://app.clickup.com/t/18022949/JOB-71

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
