### PR TITLE
Prepare repository for deployment on k8s

### DIFF
--- a/jobbergate-api/jobbergateapi2/main.py
+++ b/jobbergate-api/jobbergateapi2/main.py
@@ -5,7 +5,6 @@ import ast
 
 from fastapi import FastAPI, Response, status
 from loguru import logger
-from mangum import Mangum
 from starlette.middleware.cors import CORSMiddleware
 
 from jobbergateapi2 import storage
@@ -26,9 +25,9 @@ subapp.include_router(applications_router)
 subapp.include_router(job_scripts_router)
 subapp.include_router(job_submissions_router)
 
-@subapp.get("/health",
-    status_code=status.HTTP_204_NO_CONTENT,
-    responses={204: {"description": "API is healthy"}},
+
+@subapp.get(
+    "/health", status_code=status.HTTP_204_NO_CONTENT, responses={204: {"description": "API is healthy"}},
 )
 async def health_check():
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/jobbergate-api/jobbergateapi2/tests/apps/applications/test_routers.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/applications/test_routers.py
@@ -28,7 +28,7 @@ async def test_create_application(s3man_client_mock, application_data, client, i
     file_mock = mock.MagicMock(wraps=StringIO("test"))
 
     inject_security_header("owner1", "jobbergate:applications:create")
-    response = await client.post("/applications/", data=application_data, files={"upload_file": file_mock})
+    response = await client.post("/jobbergate/applications/", data=application_data, files={"upload_file": file_mock})
     assert response.status_code == status.HTTP_201_CREATED
     s3man.s3_client.put_object.assert_called_once()
 
@@ -63,7 +63,7 @@ async def test_create_application_bad_permission(
     file_mock = mock.MagicMock(wraps=StringIO("test"))
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.post("/applications/", data=application_data, files={"upload_file": file_mock})
+    response = await client.post("/jobbergate/applications/", data=application_data, files={"upload_file": file_mock})
     assert response.status_code == status.HTTP_403_FORBIDDEN
     s3man.s3_client.put_object.assert_not_called()
 
@@ -89,7 +89,7 @@ async def test_create_without_application_name(
 
     inject_security_header("owner1", "jobbergate:applications:create")
     application_data["application_name"] = None
-    response = await client.post("/applications/", data=application_data, files={"upload_file": file_mock})
+    response = await client.post("/jobbergate/applications/", data=application_data, files={"upload_file": file_mock})
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     s3man.s3_client.put_object.assert_not_called()
 
@@ -113,7 +113,7 @@ async def test_create_without_file(
     """
     inject_security_header("owner1", "jobbergate:applications:create")
     application_data["application_name"] = None
-    response = await client.post("/applications/", data=application_data)
+    response = await client.post("/jobbergate/applications/", data=application_data)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     s3man.s3_client.put_object.assert_not_called()
 
@@ -141,7 +141,7 @@ async def test_delete_application(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "jobbergate:applications:delete")
-    response = await client.delete("/applications/1")
+    response = await client.delete("/jobbergate/applications/1")
     assert response.status_code == status.HTTP_204_NO_CONTENT
     count = await database.fetch_all("SELECT COUNT(*) FROM applications")
     assert count[0][0] == 0
@@ -167,7 +167,7 @@ async def test_delete_application_bad_permission(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.delete("/applications/1")
+    response = await client.delete("/jobbergate/applications/1")
     assert response.status_code == status.HTTP_403_FORBIDDEN
     count = await database.fetch_all("SELECT COUNT(*) FROM applications")
     assert count[0][0] == 1
@@ -193,7 +193,7 @@ async def test_delete_application_not_found(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "jobbergate:applications:delete")
-    response = await client.delete("/applications/999")
+    response = await client.delete("/jobbergate/applications/999")
     assert response.status_code == status.HTTP_404_NOT_FOUND
     count = await database.fetch_all("SELECT COUNT(*) FROM applications")
     assert count[0][0] == 1
@@ -214,7 +214,7 @@ async def test_delete_application_without_id(
     code is returned for a request made without an application id.
     """
     inject_security_header("owner1", "jobbergate:applications:delete")
-    response = await client.delete("/applications/")
+    response = await client.delete("/jobbergate/applications/")
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     s3man.s3_client.delete_object.assert_not_called()
 
@@ -239,7 +239,7 @@ async def test_get_application_by_id(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "jobbergate:applications:read")
-    response = await client.get("/applications/1")
+    response = await client.get("/jobbergate/applications/1")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -260,7 +260,7 @@ async def test_get_application_by_id_invalid(client, inject_security_header):
     returned is what we would expect given the application requested doesn't exist (404).
     """
     inject_security_header("owner1", "jobbergate:applications:read")
-    response = await client.get("/applications/10")
+    response = await client.get("/jobbergate/applications/10")
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -278,7 +278,7 @@ async def test_get_application_by_id_bad_permission(client, application_data, in
     await insert_objects(application, applications_table)
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.get("/applications/1")
+    response = await client.get("/jobbergate/applications/1")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -302,7 +302,7 @@ async def test_get_application_all_from_user(client, application_data, inject_se
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:applications:read")
-    response = await client.get("/applications/")
+    response = await client.get("/jobbergate/applications/")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -331,7 +331,7 @@ async def test_get_application_all_from_user_bad_permission(client, application_
     assert count[0][0] == 3
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.get("/applications/")
+    response = await client.get("/jobbergate/applications/")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -356,7 +356,7 @@ async def test_get_application_all_from_user_empty(client, application_data, inj
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:applications:read")
-    response = await client.get("/applications/")
+    response = await client.get("/jobbergate/applications/")
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()) == 0
 
@@ -382,7 +382,7 @@ async def test_get_all_applications(client, application_data, inject_security_he
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:applications:read")
-    response = await client.get("/applications/?all=True")
+    response = await client.get("/jobbergate/applications/?all=True")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -411,13 +411,13 @@ async def test_get_all_applications_pagination(client, application_data, inject_
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:applications:read")
-    response = await client.get("/applications/?limit=1&skip=0")
+    response = await client.get("/jobbergate/applications/?limit=1&skip=0")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
     assert [d["id"] for d in data] == [1]
 
-    response = await client.get("/applications/?limit=2&skip=1")
+    response = await client.get("/jobbergate/applications/?limit=2&skip=1")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -449,7 +449,7 @@ async def test_update_application(s3man_client_mock, client, application_data, i
     inject_security_header("owner1", "jobbergate:applications:update")
     application_data["application_name"] = "new_name"
     application_data["application_description"] = "new_description"
-    response = await client.put("/applications/1", data=application_data, files={"upload_file": file_mock})
+    response = await client.put("/jobbergate/applications/1", data=application_data, files={"upload_file": file_mock})
     assert response.status_code == status.HTTP_201_CREATED
 
     data = response.json()
@@ -499,7 +499,7 @@ async def test_update_application_bad_permission(
     inject_security_header("owner1", "INVALID_PERMISSION")
     application_data["application_name"] = "new_name"
     application_data["application_description"] = "new_description"
-    response = await client.put("/applications/1", data=application_data, files={"upload_file": file_mock})
+    response = await client.put("/jobbergate/applications/1", data=application_data, files={"upload_file": file_mock})
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
     s3man.s3_client.put_object.assert_not_called()

--- a/jobbergate-api/jobbergateapi2/tests/apps/applications/test_routers.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/applications/test_routers.py
@@ -28,7 +28,9 @@ async def test_create_application(s3man_client_mock, application_data, client, i
     file_mock = mock.MagicMock(wraps=StringIO("test"))
 
     inject_security_header("owner1", "jobbergate:applications:create")
-    response = await client.post("/jobbergate/applications/", data=application_data, files={"upload_file": file_mock})
+    response = await client.post(
+        "/jobbergate/applications/", data=application_data, files={"upload_file": file_mock}
+    )
     assert response.status_code == status.HTTP_201_CREATED
     s3man.s3_client.put_object.assert_called_once()
 
@@ -63,7 +65,9 @@ async def test_create_application_bad_permission(
     file_mock = mock.MagicMock(wraps=StringIO("test"))
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.post("/jobbergate/applications/", data=application_data, files={"upload_file": file_mock})
+    response = await client.post(
+        "/jobbergate/applications/", data=application_data, files={"upload_file": file_mock}
+    )
     assert response.status_code == status.HTTP_403_FORBIDDEN
     s3man.s3_client.put_object.assert_not_called()
 
@@ -89,7 +93,9 @@ async def test_create_without_application_name(
 
     inject_security_header("owner1", "jobbergate:applications:create")
     application_data["application_name"] = None
-    response = await client.post("/jobbergate/applications/", data=application_data, files={"upload_file": file_mock})
+    response = await client.post(
+        "/jobbergate/applications/", data=application_data, files={"upload_file": file_mock}
+    )
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     s3man.s3_client.put_object.assert_not_called()
 
@@ -449,7 +455,9 @@ async def test_update_application(s3man_client_mock, client, application_data, i
     inject_security_header("owner1", "jobbergate:applications:update")
     application_data["application_name"] = "new_name"
     application_data["application_description"] = "new_description"
-    response = await client.put("/jobbergate/applications/1", data=application_data, files={"upload_file": file_mock})
+    response = await client.put(
+        "/jobbergate/applications/1", data=application_data, files={"upload_file": file_mock}
+    )
     assert response.status_code == status.HTTP_201_CREATED
 
     data = response.json()
@@ -499,7 +507,9 @@ async def test_update_application_bad_permission(
     inject_security_header("owner1", "INVALID_PERMISSION")
     application_data["application_name"] = "new_name"
     application_data["application_description"] = "new_description"
-    response = await client.put("/jobbergate/applications/1", data=application_data, files={"upload_file": file_mock})
+    response = await client.put(
+        "/jobbergate/applications/1", data=application_data, files={"upload_file": file_mock}
+    )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
     s3man.s3_client.put_object.assert_not_called()

--- a/jobbergate-api/jobbergateapi2/tests/apps/job_scripts/test_routers.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/job_scripts/test_routers.py
@@ -123,7 +123,7 @@ async def test_create_job_script(
 
     inject_security_header("owner1", "jobbergate:job-scripts:create")
     job_script_data["param_dict"] = json.dumps(param_dict)
-    response = await client.post("/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
+    response = await client.post("/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
     assert response.status_code == status.HTTP_201_CREATED
     s3man_client_mock.get_object.assert_called_once()
 
@@ -164,7 +164,7 @@ async def test_create_job_script_bad_permission(
 
     inject_security_header("owner1", "INVALID_PERMISSION")
     job_script_data["param_dict"] = json.dumps(param_dict)
-    response = await client.post("/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
+    response = await client.post("/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
     assert response.status_code == status.HTTP_403_FORBIDDEN
     s3man_client_mock.get_object.assert_not_called()
 
@@ -190,7 +190,7 @@ async def test_create_job_script_without_application(
 
     inject_security_header("owner1", "jobbergate:job-scripts:create")
     job_script_data["param_dict"] = json.dumps(param_dict)
-    response = await client.post("/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
+    response = await client.post("/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
     assert response.status_code == status.HTTP_404_NOT_FOUND
     s3man_client_mock.get_object.assert_not_called()
 
@@ -221,7 +221,7 @@ async def test_create_job_script_file_not_found(
 
     inject_security_header("owner1", "jobbergate:job-scripts:create")
     job_script_data["param_dict"] = json.dumps(param_dict)
-    response = await client.post("/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
+    response = await client.post("/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
     assert response.status_code == status.HTTP_404_NOT_FOUND
     s3man_client_mock.get_object.assert_called_once()
 
@@ -302,7 +302,7 @@ async def test_get_job_script_by_id(client, application_data, job_script_data, i
     assert count[0][0] == 1
 
     inject_security_header("owner1", "jobbergate:job-scripts:read")
-    response = await client.get("/job-scripts/1")
+    response = await client.get("/jobbergate/job-scripts/1")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -324,7 +324,7 @@ async def test_get_job_script_by_id_invalid(client, inject_security_header):
     returned is what we would expect given the job_script requested doesn't exist (404).
     """
     inject_security_header("owner1", "jobbergate:job-scripts:read")
-    response = await client.get("/job-scripts/10")
+    response = await client.get("/jobbergate/job-scripts/10")
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -347,7 +347,7 @@ async def test_get_job_script_by_id_bad_permission(
     await insert_objects(job_script, job_scripts_table)
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.get("/job-scripts/1")
+    response = await client.get("/jobbergate/job-scripts/1")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -376,7 +376,7 @@ async def test_list_job_script_from_user(client, application_data, job_script_da
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:job-scripts:read")
-    response = await client.get("/job-scripts/")
+    response = await client.get("/jobbergate/job-scripts/")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -408,7 +408,7 @@ async def test_list_job_script_bad_permission(
     assert count[0][0] == 3
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.get("/job-scripts/")
+    response = await client.get("/jobbergate/job-scripts/")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -440,7 +440,7 @@ async def test_list_job_script_from_user_empty(
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:job-scripts:read")
-    response = await client.get("/job-scripts/")
+    response = await client.get("/jobbergate/job-scripts/")
     assert response.status_code == status.HTTP_200_OK
 
     assert len(response.json()) == 0
@@ -474,7 +474,7 @@ async def test_list_job_script_all(
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:job-scripts:read")
-    response = await client.get("/job-scripts/?all=True")
+    response = await client.get("/jobbergate/job-scripts/?all=True")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -510,13 +510,13 @@ async def test_list_job_script_pagination(
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:job-scripts:read")
-    response = await client.get("/job-scripts/?limit=1&skip=0")
+    response = await client.get("/jobbergate/job-scripts/?limit=1&skip=0")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
     assert [d["id"] for d in data] == [1]
 
-    response = await client.get("/job-scripts/?limit=2&skip=1")
+    response = await client.get("/jobbergate/job-scripts/?limit=2&skip=1")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -544,7 +544,7 @@ async def test_update_job_script(
 
     inject_security_header("owner1", "jobbergate:job-scripts:update")
     response = await client.put(
-        "/job-scripts/1",
+        "/jobbergate/job-scripts/1",
         data={
             "job_script_name": "new name",
             "job_script_description": "new description",
@@ -591,7 +591,7 @@ async def test_update_job_script_not_found(
     await insert_objects(job_scripts, job_scripts_table)
 
     inject_security_header("owner1", "jobbergate:job-scripts:update")
-    response = await client.put("/job-scripts/123", data={"job_script_name": "new name"})
+    response = await client.put("/jobbergate/job-scripts/123", data={"job_script_name": "new name"})
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -621,7 +621,7 @@ async def test_update_job_script_bad_permission(
     await insert_objects(job_scripts, job_scripts_table)
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.put("/job-scripts/1", data={"job_script_name": "new name"})
+    response = await client.put("/jobbergate/job-scripts/1", data={"job_script_name": "new name"})
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -654,7 +654,7 @@ async def test_delete_job_script(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "jobbergate:job-scripts:delete")
-    response = await client.delete("/job-scripts/1")
+    response = await client.delete("/jobbergate/job-scripts/1")
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -684,7 +684,7 @@ async def test_delete_job_script_not_found(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "jobbergate:job-scripts:delete")
-    response = await client.delete("/job-scripts/123")
+    response = await client.delete("/jobbergate/job-scripts/123")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -714,7 +714,7 @@ async def test_delete_job_script_bad_permission(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.delete("/job-scripts/1")
+    response = await client.delete("/jobbergate/job-scripts/1")
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
 

--- a/jobbergate-api/jobbergateapi2/tests/apps/job_scripts/test_routers.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/job_scripts/test_routers.py
@@ -123,7 +123,9 @@ async def test_create_job_script(
 
     inject_security_header("owner1", "jobbergate:job-scripts:create")
     job_script_data["param_dict"] = json.dumps(param_dict)
-    response = await client.post("/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
+    response = await client.post(
+        "/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock}
+    )
     assert response.status_code == status.HTTP_201_CREATED
     s3man_client_mock.get_object.assert_called_once()
 
@@ -164,7 +166,9 @@ async def test_create_job_script_bad_permission(
 
     inject_security_header("owner1", "INVALID_PERMISSION")
     job_script_data["param_dict"] = json.dumps(param_dict)
-    response = await client.post("/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
+    response = await client.post(
+        "/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock}
+    )
     assert response.status_code == status.HTTP_403_FORBIDDEN
     s3man_client_mock.get_object.assert_not_called()
 
@@ -190,7 +194,9 @@ async def test_create_job_script_without_application(
 
     inject_security_header("owner1", "jobbergate:job-scripts:create")
     job_script_data["param_dict"] = json.dumps(param_dict)
-    response = await client.post("/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
+    response = await client.post(
+        "/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock}
+    )
     assert response.status_code == status.HTTP_404_NOT_FOUND
     s3man_client_mock.get_object.assert_not_called()
 
@@ -221,7 +227,9 @@ async def test_create_job_script_file_not_found(
 
     inject_security_header("owner1", "jobbergate:job-scripts:create")
     job_script_data["param_dict"] = json.dumps(param_dict)
-    response = await client.post("/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock})
+    response = await client.post(
+        "/jobbergate/job-scripts/", data=job_script_data, files={"upload_file": file_mock}
+    )
     assert response.status_code == status.HTTP_404_NOT_FOUND
     s3man_client_mock.get_object.assert_called_once()
 

--- a/jobbergate-api/jobbergateapi2/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/job_submissions/test_routers.py
@@ -35,7 +35,7 @@ async def test_create_job_submission(
     await insert_objects(job_script, job_scripts_table)
 
     inject_security_header("owner1", "jobbergate:job-submissions:create")
-    response = await client.post("/job-submissions/", json=job_submission_data)
+    response = await client.post("/jobbergate/job-submissions/", json=job_submission_data)
     assert response.status_code == status.HTTP_201_CREATED
 
     count = await database.fetch_all("SELECT COUNT(*) FROM job_submissions")
@@ -53,7 +53,7 @@ async def test_create_job_submission_without_job_script(client, job_submission_d
     the job_submission still does not exists in the database, the correct status code (404) is returned.
     """
     inject_security_header("owner1", "jobbergate:job-submissions:create")
-    response = await client.post("/job-submissions/", json=job_submission_data)
+    response = await client.post("/jobbergate/job-submissions/", json=job_submission_data)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
     count = await database.fetch_all("SELECT COUNT(*) FROM job_submissions")
@@ -79,7 +79,7 @@ async def test_create_job_submission_bad_permission(
     await insert_objects(job_script, job_scripts_table)
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.post("/job-submissions/", json=job_submission_data)
+    response = await client.post("/jobbergate/job-submissions/", json=job_submission_data)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
     count = await database.fetch_all("SELECT COUNT(*) FROM job_submissions")
@@ -112,7 +112,7 @@ async def test_get_job_submission_by_id(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "jobbergate:job-submissions:read")
-    response = await client.get("/job-submissions/1")
+    response = await client.get("/jobbergate/job-submissions/1")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -143,7 +143,7 @@ async def test_get_job_submission_by_id_bad_permission(
     await insert_objects(job_submissions, job_submissions_table)
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.get("/job-submissions/1")
+    response = await client.get("/jobbergate/job-submissions/1")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -158,7 +158,7 @@ async def test_get_job_submission_by_id_invalid(client, inject_security_header):
     returned is what we would expect given the job_submission requested doesn't exist (404).
     """
     inject_security_header("owner1", "jobbergate:job-submissions:read")
-    response = await client.get("/job-submissions/10")
+    response = await client.get("/jobbergate/job-submissions/10")
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -191,7 +191,7 @@ async def test_list_job_submission_from_user(
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:job-submissions:read")
-    response = await client.get("/job-submissions/")
+    response = await client.get("/jobbergate/job-submissions/")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -228,7 +228,7 @@ async def test_list_job_submission_bad_permission(
     assert count[0][0] == 3
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.get("/job-submissions/")
+    response = await client.get("/jobbergate/job-submissions/")
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -262,7 +262,7 @@ async def test_list_job_submission_from_user_empty(
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:job-submissions:read")
-    response = await client.get("/job-submissions/")
+    response = await client.get("/jobbergate/job-submissions/")
     assert response.status_code == status.HTTP_200_OK
 
     assert len(response.json()) == 0
@@ -298,7 +298,7 @@ async def test_list_job_submission_all(
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:job-submissions:read")
-    response = await client.get("/job-submissions/?all=True")
+    response = await client.get("/jobbergate/job-submissions/?all=True")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -336,13 +336,13 @@ async def test_list_job_submission_pagination(
     assert count[0][0] == 3
 
     inject_security_header("owner1", "jobbergate:job-submissions:read")
-    response = await client.get("/job-submissions/?limit=1&skip=0")
+    response = await client.get("/jobbergate/job-submissions/?limit=1&skip=0")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
     assert [d["id"] for d in data] == [1]
 
-    response = await client.get("/job-submissions/?limit=2&skip=1")
+    response = await client.get("/jobbergate/job-submissions/?limit=2&skip=1")
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
@@ -373,7 +373,7 @@ async def test_update_job_submission(
 
     inject_security_header("owner1", "jobbergate:job-submissions:update")
     response = await client.put(
-        "/job-submissions/1",
+        "/jobbergate/job-submissions/1",
         data={"job_submission_name": "new name", "job_submission_description": "new description"},
     )
 
@@ -417,7 +417,7 @@ async def test_update_job_submission_not_found(
     await insert_objects(job_submissions, job_submissions_table)
 
     inject_security_header("owner1", "jobbergate:job-submissions:update")
-    response = await client.put("/job-submissions/123", data={"job_submission_name": "new name"})
+    response = await client.put("/jobbergate/job-submissions/123", data={"job_submission_name": "new name"})
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -450,7 +450,7 @@ async def test_update_job_submission_bad_permission(
     await insert_objects(job_submissions, job_submissions_table)
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.put("/job-submissions/1", data={"job_submission_name": "new name"})
+    response = await client.put("/jobbergate/job-submissions/1", data={"job_submission_name": "new name"})
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -486,7 +486,7 @@ async def test_delete_job_submission(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "jobbergate:job-submissions:delete")
-    response = await client.delete("/job-submissions/1")
+    response = await client.delete("/jobbergate/job-submissions/1")
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -519,7 +519,7 @@ async def test_delete_job_submission_not_found(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "jobbergate:job-submissions:delete")
-    response = await client.delete("/job-submissions/123")
+    response = await client.delete("/jobbergate/job-submissions/123")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -552,7 +552,7 @@ async def test_delete_job_submission_bad_permission(
     assert count[0][0] == 1
 
     inject_security_header("owner1", "INVALID_PERMISSION")
-    response = await client.delete("/job-submissions/1")
+    response = await client.delete("/jobbergate/job-submissions/1")
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
 

--- a/jobbergate-api/jobbergateapi2/tests/apps/test_main.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/test_main.py
@@ -1,0 +1,17 @@
+import pytest
+from httpx import AsyncClient
+from fastapi import status
+
+
+@pytest.mark.asyncio
+async def test_health_check(test_client: AsyncClient):
+    """
+    Test the health check route
+
+    This test ensures the API has a health check path configured properly, so
+    the production and staging environments can configure the load balancing
+    """
+
+    response = await test_client.get("/jobbergate/health")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/jobbergate-api/jobbergateapi2/tests/apps/test_main.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/test_main.py
@@ -4,7 +4,7 @@ from fastapi import status
 
 
 @pytest.mark.asyncio
-async def test_health_check(test_client: AsyncClient):
+async def test_health_check(client: AsyncClient):
     """
     Test the health check route
 
@@ -12,6 +12,6 @@ async def test_health_check(test_client: AsyncClient):
     the production and staging environments can configure the load balancing
     """
 
-    response = await test_client.get("/jobbergate/health")
+    response = await client.get("/jobbergate/health")
 
     assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/jobbergate-api/jobbergateapi2/tests/apps/test_main.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/test_main.py
@@ -1,6 +1,6 @@
 import pytest
-from httpx import AsyncClient
 from fastapi import status
+from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/jobbergate-api/jobbergateapi2/tests/apps/test_main.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/test_main.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 @pytest.mark.asyncio
 async def test_health_check(client: AsyncClient):
     """
-    Test the health check route
+    Test the health check route.
 
     This test ensures the API has a health check path configured properly, so
     the production and staging environments can configure the load balancing


### PR DESCRIPTION
#### What
This PR makes slightly changes in the API:

1. implements a health check route;
2. changes the API structure

The main difference is the app became a subapp to be mounted into a higher level app

#### Why
This is needed to better prepare the API to deploy on k8s. The main reason is to be able to allocate the API in an Ingress resource. To do that, it's needed to add the prefix `/jobbergate` to all routes. It could be done at the routers context but I chose to do it at the app level

`Task`: none

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
