### PR TITLE
Fixed broken unit tests

### DIFF
--- a/jobbergate-api/jobbergateapi2/apps/applications/routers.py
+++ b/jobbergate-api/jobbergateapi2/apps/applications/routers.py
@@ -75,7 +75,6 @@ async def application_delete(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"Application {application_id=} not found.",
         )
-    application = Application.parse_obj(raw_application)
     delete_query = applications_table.delete().where(where_stmt)
     await database.execute(delete_query)
     s3man.delete(app_id=str(application_id))

--- a/jobbergate-api/jobbergateapi2/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergateapi2/apps/job_scripts/routers.py
@@ -47,16 +47,16 @@ def inject_sbatch_params(job_script_data_as_string: str, sbatch_params: List[str
     return new_job_script_data_as_string
 
 
-def get_s3_object_as_tarfile(current_user_id, application_id):
+def get_s3_object_as_tarfile(application_id):
     """
     Return the tarfile of a S3 object.
     """
     try:
-        s3_application_obj = s3man.get(owner_id=current_user_id, app_id=application_id)
+        s3_application_obj = s3man.get(app_id=application_id)
     except BotoCoreError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Application with id={application_id} not found for user={current_user_id} in S3",
+            detail=f"Application with id={application_id} not found in S3",
         )
     s3_application_tar = tarfile.open(fileobj=BytesIO(s3_application_obj["Body"].read()))
     return s3_application_tar
@@ -151,7 +151,7 @@ async def job_script_create(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"Application with id={application_id} not found.",
         )
     application = Application.parse_obj(raw_application)
-    s3_application_tar = get_s3_object_as_tarfile(token_payload.sub, application.id)
+    s3_application_tar = get_s3_object_as_tarfile(application.id)
 
     job_script_data_as_string = build_job_script_data_as_string(s3_application_tar, _param_dict)
 

--- a/jobbergate-api/jobbergateapi2/config.py
+++ b/jobbergate-api/jobbergateapi2/config.py
@@ -20,8 +20,8 @@ class Settings(BaseSettings):
     # S3 configuration
     S3_BUCKET_NAME: str = Field("jobbergate-staging-eu-north-1-resources")
     S3_ENDPOINT_URL: Optional[str]
-    AWS_ACCESS_KEY_ID: str
-    AWS_SECRET_ACCESS_KEY: str
+    AWS_ACCESS_KEY_ID: Optional[str]
+    AWS_SECRET_ACCESS_KEY: Optional[str]
 
     # BACKEND_CORS_ORIGINS example: "['https://example1.com', 'https://example2.com']"
     BACKEND_CORS_ORIGINS: str = Field("[]")

--- a/jobbergate-api/jobbergateapi2/s3_manager.py
+++ b/jobbergate-api/jobbergateapi2/s3_manager.py
@@ -22,7 +22,6 @@ class S3Manager:
             endpoint_url=settings.S3_ENDPOINT_URL,
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-
         )
 
     def _get_key(self, app_id):

--- a/jobbergate-api/jobbergateapi2/tests/apps/job_scripts/test_routers.py
+++ b/jobbergate-api/jobbergateapi2/tests/apps/job_scripts/test_routers.py
@@ -246,7 +246,7 @@ async def test_get_s3_object_as_tarfile(s3man_client_mock, param_dict, s3_object
     """
     s3man_client_mock.get_object.return_value = s3_object
 
-    s3_file = get_s3_object_as_tarfile(1, 1)
+    s3_file = get_s3_object_as_tarfile(1)
 
     assert s3_file is not None
     s3man_client_mock.get_object.assert_called_once()
@@ -263,9 +263,9 @@ def test_get_s3_object_not_found(
 
     s3_file = None
     with pytest.raises(HTTPException) as exc:
-        s3_file = get_s3_object_as_tarfile(1, 1)
+        s3_file = get_s3_object_as_tarfile(1)
 
-    assert "Application with id=1 not found for user=1" in str(exc)
+    assert "Application with id=1 not found" in str(exc)
 
     assert s3_file is None
     s3man_client_mock.get_object.assert_called_once()


### PR DESCRIPTION
#### What
Fixed broken unit tests.

#### Why
Unit tests were breaking due to:
* Required AWS credentials (these should be optional)
* Incorrect parameters to the revised s3 manger get_applications() method


---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
