### PR TITLE
Remove CORS allowed origins parameter from settings

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -7,6 +7,10 @@ This file keeps track of all notable changes to jobbergate-api
 Unreleased
 ----------
 
+2.0.1 -- 2021-12-10
+-------------------
+* Removed CORS origins parameter from settings and set all origins as the allowed ones
+
 2.0.0 -- 2021-12-08
 -------------------
 * Added support for auth via Armasec & Auth0

--- a/jobbergate-api/jobbergate_api/config.py
+++ b/jobbergate-api/jobbergate_api/config.py
@@ -34,9 +34,6 @@ class Settings(BaseSettings):
     AWS_ACCESS_KEY_ID: Optional[str]
     AWS_SECRET_ACCESS_KEY: Optional[str]
 
-    # BACKEND_CORS_ORIGINS example: "['https://example1.com', 'https://example2.com']"
-    BACKEND_CORS_ORIGINS: str = Field("[]")
-
     # Security Settings. For details, see https://github.com/omnivector-solutions/armsec
     ARMASEC_DOMAIN: str
     ARMASEC_AUDIENCE: Optional[HttpUrl]

--- a/jobbergate-api/jobbergate_api/main.py
+++ b/jobbergate-api/jobbergate_api/main.py
@@ -1,7 +1,6 @@
 """
 Main file to startup the fastapi server
 """
-import ast
 import sys
 
 import sentry_sdk
@@ -19,7 +18,7 @@ from jobbergate_api.config import settings
 subapp = FastAPI()
 subapp.add_middleware(
     CORSMiddleware,
-    allow_origins=[str(origin) for origin in ast.literal_eval(settings.BACKEND_CORS_ORIGINS)],
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/jobbergate-api/jobbergate_api/main.py
+++ b/jobbergate-api/jobbergate_api/main.py
@@ -17,11 +17,7 @@ from jobbergate_api.config import settings
 
 subapp = FastAPI()
 subapp.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"],
 )
 
 if settings.SENTRY_DSN:

--- a/jobbergate-api/pyproject.toml
+++ b/jobbergate-api/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 name = "jobbergate-api"
 description = "Jobbergate API"
 license = "MIT"
-version = "2.0.0"
+version = "2.0.1"
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
#### What
This PR removes the `BACKEND_CORS_ORIGINS` parameter from the settings class.

#### Why
Needed to better set the API on k8s

`Task`: https://omnivector-solutions.monday.com/boards/XXXX/pulses/YYYY

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
