### PR TITLE
JOB-121 Simplified permissions to read/edit on all endpoints

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+* Revised permissions do use a view/edit model for each data model
 
 2.1.1 -- 2022-01-13
 -------------------

--- a/jobbergate-api/jobbergate_api/apps/applications/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/applications/routers.py
@@ -12,6 +12,7 @@ from jobbergate_api.apps.applications.schemas import (
     ApplicationResponse,
     ApplicationUpdateRequest,
 )
+from jobbergate_api.apps.permissions import Permissions
 from jobbergate_api.compat import INTEGRITY_CHECK_EXCEPTIONS
 from jobbergate_api.config import settings
 from jobbergate_api.pagination import Pagination, Response, package_response
@@ -31,7 +32,7 @@ s3man = S3Manager()
 )
 async def applications_create(
     application: ApplicationCreateRequest,
-    token_payload: TokenPayload = Depends(guard.lockdown("jobbergate:applications:create")),
+    token_payload: TokenPayload = Depends(guard.lockdown(Permissions.APPLICATIONS_EDIT)),
 ):
     """
     Create new applications using an authenticated user token.
@@ -63,7 +64,7 @@ async def applications_create(
         "Endpoint for uploading application files. "
         "The file should be a gzipped tar-file (e.g. `jobbergate.tar.gz`)."
     ),
-    dependencies=[Depends(guard.lockdown("jobbergate:applications:upload"))],
+    dependencies=[Depends(guard.lockdown(Permissions.APPLICATIONS_EDIT))],
 )
 async def applications_upload(
     application_id: int = Query(..., description="id of the application for which to upload a file"),
@@ -93,7 +94,7 @@ async def applications_upload(
     "/applications/{application_id}/upload",
     status_code=status.HTTP_204_NO_CONTENT,
     description="Endpoint for deleting application tarballs",
-    dependencies=[Depends(guard.lockdown("jobbergate:applications:upload"))],
+    dependencies=[Depends(guard.lockdown(Permissions.APPLICATIONS_EDIT))],
 )
 async def applications_delete(
     application_id: int = Query(..., description="id of the application for which to delete the file"),
@@ -127,7 +128,7 @@ async def applications_delete(
     "/applications/{application_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     description="Endpoint to delete application",
-    dependencies=[Depends(guard.lockdown("jobbergate:applications:delete"))],
+    dependencies=[Depends(guard.lockdown(Permissions.APPLICATIONS_EDIT))],
 )
 async def application_delete(
     application_id: int = Query(..., description="id of the application to delete"),
@@ -162,7 +163,7 @@ async def applications_list(
     user: bool = Query(False),
     all: bool = Query(False),
     pagination: Pagination = Depends(),
-    token_payload: TokenPayload = Depends(guard.lockdown("jobbergate:applications:read")),
+    token_payload: TokenPayload = Depends(guard.lockdown(Permissions.APPLICATIONS_VIEW)),
 ):
     """
     List all applications
@@ -180,7 +181,7 @@ async def applications_list(
     "/applications/{application_id}",
     description="Endpoint to return an application given the id",
     response_model=ApplicationResponse,
-    dependencies=[Depends(guard.lockdown("jobbergate:applications:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.APPLICATIONS_VIEW))],
 )
 async def applications_get_by_id(application_id: int = Query(...)):
     """
@@ -202,7 +203,7 @@ async def applications_get_by_id(application_id: int = Query(...)):
     status_code=status.HTTP_201_CREATED,
     description="Endpoint to update an application given the id",
     response_model=ApplicationResponse,
-    dependencies=[Depends(guard.lockdown("jobbergate:applications:update"))],
+    dependencies=[Depends(guard.lockdown(Permissions.APPLICATIONS_EDIT))],
 )
 async def application_update(
     application_id: int, application: ApplicationUpdateRequest,

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -20,6 +20,7 @@ from jobbergate_api.apps.job_scripts.schemas import (
     JobScriptResponse,
     JobScriptUpdateRequest,
 )
+from jobbergate_api.apps.permissions import Permissions
 from jobbergate_api.compat import INTEGRITY_CHECK_EXCEPTIONS
 from jobbergate_api.pagination import Pagination, Response, package_response
 from jobbergate_api.s3_manager import S3Manager
@@ -139,7 +140,7 @@ def build_job_script_data_as_string(s3_application_tar, param_dict):
 )
 async def job_script_create(
     job_script: JobScriptCreateRequest,
-    token_payload: TokenPayload = Depends(guard.lockdown("jobbergate:job-scripts:create")),
+    token_payload: TokenPayload = Depends(guard.lockdown(Permissions.JOB_SCRIPTS_EDIT)),
 ):
     """
     Create a new job script.
@@ -188,7 +189,7 @@ async def job_script_create(
     "/job-scripts/{job_script_id}",
     description="Endpoint to get a job_script",
     response_model=JobScriptResponse,
-    dependencies=[Depends(guard.lockdown("jobbergate:job-scripts:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.JOB_SCRIPTS_VIEW))],
 )
 async def job_script_get(job_script_id: int = Query(...)):
     """
@@ -211,7 +212,7 @@ async def job_script_get(job_script_id: int = Query(...)):
 async def job_script_list(
     pagination: Pagination = Depends(),
     all: Optional[bool] = Query(False),
-    token_payload: TokenPayload = Depends(guard.lockdown("jobbergate:job-scripts:read")),
+    token_payload: TokenPayload = Depends(guard.lockdown(Permissions.JOB_SCRIPTS_VIEW)),
 ):
     """
     List job_scripts for the authenticated user.
@@ -227,7 +228,7 @@ async def job_script_list(
     "/job-scripts/{job_script_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     description="Endpoint to delete job script",
-    dependencies=[Depends(guard.lockdown("jobbergate:job-scripts:delete"))],
+    dependencies=[Depends(guard.lockdown(Permissions.JOB_SCRIPTS_EDIT))],
 )
 async def job_script_delete(job_script_id: int = Query(..., description="id of the job script to delete")):
     """
@@ -252,7 +253,7 @@ async def job_script_delete(job_script_id: int = Query(..., description="id of t
     status_code=status.HTTP_201_CREATED,
     description="Endpoint to update a job_script given the id",
     response_model=JobScriptResponse,
-    dependencies=[Depends(guard.lockdown("jobbergate:job-scripts:update"))],
+    dependencies=[Depends(guard.lockdown(Permissions.JOB_SCRIPTS_EDIT))],
 )
 async def job_script_update(
     job_script_id: int, job_script: JobScriptUpdateRequest,

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -13,6 +13,7 @@ from jobbergate_api.apps.job_submissions.schemas import (
     JobSubmissionResponse,
     JobSubmissionUpdateRequest,
 )
+from jobbergate_api.apps.permissions import Permissions
 from jobbergate_api.compat import INTEGRITY_CHECK_EXCEPTIONS
 from jobbergate_api.pagination import Pagination, Response, package_response
 from jobbergate_api.security import IdentityClaims, guard
@@ -24,7 +25,7 @@ router = APIRouter()
 @router.post("/job-submissions/", status_code=201, description="Endpoint for job_submission creation")
 async def job_submission_create(
     job_submission: JobSubmissionCreateRequest,
-    token_payload: TokenPayload = Depends(guard.lockdown("jobbergate:job-submissions:create")),
+    token_payload: TokenPayload = Depends(guard.lockdown(Permissions.JOB_SUBMISSIONS_EDIT)),
 ):
     """
     Create a new job submission.
@@ -63,7 +64,7 @@ async def job_submission_create(
     "/job-submissions/{job_submission_id}",
     description="Endpoint to get a job_submission",
     response_model=JobSubmissionResponse,
-    dependencies=[Depends(guard.lockdown("jobbergate:job-submissions:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.JOB_SUBMISSIONS_VIEW))],
 )
 async def job_submission_get(job_submission_id: int = Query(...)):
     """
@@ -88,7 +89,7 @@ async def job_submission_get(job_submission_id: int = Query(...)):
 async def job_submission_list(
     pagination: Pagination = Depends(),
     all: Optional[bool] = Query(None),
-    token_payload: TokenPayload = Depends(guard.lockdown("jobbergate:job-submissions:read")),
+    token_payload: TokenPayload = Depends(guard.lockdown(Permissions.JOB_SUBMISSIONS_VIEW)),
 ):
     """
     List job_submissions for the authenticated user.
@@ -104,7 +105,7 @@ async def job_submission_list(
     "/job-submissions/{job_submission_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     description="Endpoint to delete job submission",
-    dependencies=[Depends(guard.lockdown("jobbergate:job-submissions:delete"))],
+    dependencies=[Depends(guard.lockdown(Permissions.JOB_SUBMISSIONS_EDIT))],
 )
 async def job_submission_delete(
     job_submission_id: int = Query(..., description="id of the job submission to delete"),
@@ -131,7 +132,7 @@ async def job_submission_delete(
     status_code=status.HTTP_201_CREATED,
     description="Endpoint to update a job_submission given the id",
     response_model=JobSubmissionResponse,
-    dependencies=[Depends(guard.lockdown("jobbergate:job-submissions:update"))],
+    dependencies=[Depends(guard.lockdown(Permissions.JOB_SUBMISSIONS_EDIT))],
 )
 async def job_script_update(job_submission_id: int, job_submission: JobSubmissionUpdateRequest):
     """

--- a/jobbergate-api/jobbergate_api/apps/permissions.py
+++ b/jobbergate-api/jobbergate_api/apps/permissions.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class Permissions(str, Enum):
+    """
+    Describe the permissions that may be used for protecting Jobbergate routes.
+    """
+
+    APPLICATIONS_VIEW = "jobbergate:applications:view"
+    APPLICATIONS_EDIT = "jobbergate:applications:edit"
+    JOB_SCRIPTS_VIEW = "jobbergate:job-scripts:view"
+    JOB_SCRIPTS_EDIT = "jobbergate:job-scripts:edit"
+    JOB_SUBMISSIONS_VIEW = "jobbergate:job-submissions:view"
+    JOB_SUBMISSIONS_EDIT = "jobbergate:job-submissions:edit"

--- a/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
@@ -8,6 +8,7 @@ from jobbergate_api.apps.applications.models import applications_table
 from jobbergate_api.apps.job_scripts.models import job_scripts_table
 from jobbergate_api.apps.job_submissions.models import job_submissions_table
 from jobbergate_api.apps.job_submissions.schemas import JobSubmissionResponse
+from jobbergate_api.apps.permissions import Permissions
 from jobbergate_api.storage import database
 
 
@@ -32,7 +33,7 @@ async def test_create_job_submission(
         values=dict(application_id=inserted_application_id, **job_script_data,),
     )
 
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:create")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_EDIT)
     with time_frame() as window:
         response = await client.post(
             "/jobbergate/job-submissions/",
@@ -67,7 +68,7 @@ async def test_create_job_submission_without_job_script(client, job_submission_d
     We show this by trying to create a job_submission without a job_script created before, then assert that
     the job_submission still does not exists in the database, the correct status code (404) is returned.
     """
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:create")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_EDIT)
     response = await client.post(
         "/jobbergate/job-submissions/", json=dict(job_script_id=9999, **job_submission_data,)
     )
@@ -142,7 +143,7 @@ async def test_get_job_submission_by_id(
     count = await database.fetch_all("SELECT COUNT(*) FROM job_submissions")
     assert count[0][0] == 1
 
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:read")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_VIEW)
     response = await client.get(f"/jobbergate/job-submissions/{inserted_job_submission_id}")
     assert response.status_code == status.HTTP_200_OK
 
@@ -196,7 +197,7 @@ async def test_get_job_submission_by_id_invalid(client, inject_security_header):
     requested job_submission does not exist. We show this by asserting that the status code
     returned is what we would expect given the job_submission requested doesn't exist (404).
     """
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:read")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_VIEW)
     response = await client.get("/jobbergate/job-submissions/9999")
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -248,7 +249,7 @@ async def test_get_job_submissions__no_param(
     count = await database.fetch_all("SELECT COUNT(*) FROM job_submissions")
     assert count[0][0] == 3
 
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:read")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_VIEW)
     response = await client.get("/jobbergate/job-submissions/")
     assert response.status_code == status.HTTP_200_OK
 
@@ -345,7 +346,7 @@ async def test_get_job_submissions__with_all_param(
     count = await database.fetch_all("SELECT COUNT(*) FROM job_submissions")
     assert count[0][0] == 3
 
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:read")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_VIEW)
     response = await client.get("/jobbergate/job-submissions/?all=True")
     assert response.status_code == status.HTTP_200_OK
 
@@ -393,7 +394,7 @@ async def test_list_job_submission_pagination(
     count = await database.fetch_all("SELECT COUNT(*) FROM job_submissions")
     assert count[0][0] == 5
 
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:read")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_VIEW)
     response = await client.get("/jobbergate/job-submissions/?start=0&limit=1")
     assert response.status_code == status.HTTP_200_OK
 
@@ -458,7 +459,7 @@ async def test_update_job_submission(
         ),
     )
 
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:update")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_EDIT)
     with time_frame() as window:
         response = await client.put(
             f"/jobbergate/job-submissions/{inserted_job_submission_id}",
@@ -490,7 +491,7 @@ async def test_update_job_submission_not_found(client, inject_security_header):
     This test proves that it is not possible to update a job_submission if it is not found. We show this by
     asserting that the response status code of the request is 404.
     """
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:update")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_EDIT)
     response = await client.put("/jobbergate/job-submissions/9999", json=dict(job_submission_name="new name"))
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -572,7 +573,7 @@ async def test_delete_job_submission(
     count = await database.fetch_all("SELECT COUNT(*) FROM job_submissions")
     assert count[0][0] == 1
 
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:delete")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_EDIT)
     response = await client.delete(f"/jobbergate/job-submissions/{inserted_job_submission_id}")
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
@@ -590,7 +591,7 @@ async def test_delete_job_submission_not_found(client, inject_security_header):
     This test proves that it is not possible to delete a job_submission if it does not exists. We show this
     by asserting that a 404 response status code is returned.
     """
-    inject_security_header("owner1@org.com", "jobbergate:job-submissions:delete")
+    inject_security_header("owner1@org.com", Permissions.JOB_SUBMISSIONS_EDIT)
     response = await client.delete("/jobbergate/job-submissions/9999")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
#### What
Instead of maintaining 4 (or 5) different permission types for all the Jobbergate entities, we condensed it down to to two apiece: view or edit

#### Why
This will drastically reduce the number of permissions that we need to track in our apps and our OIDC provider. It's also most likely that permissions that fine-grained wouldn't even be used anyway.

`Task`: https://app.clickup.com/t/18022949/JOB-121

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
