### PR TITLE
Fixed parameters to api for create job scripts and submissions

### DIFF
--- a/jobbergate-cli/jobbergate_cli/constants.py
+++ b/jobbergate-cli/jobbergate_cli/constants.py
@@ -15,14 +15,14 @@ JOBBERGATE_JOB_SCRIPT_CONFIG = {
     "job_script_name": "",
     "job_script_description": "TEST_DESC",
     "job_script_owner_email": "",
-    "application": "",
+    "application_id": "",
 }
 
 JOBBERGATE_JOB_SUBMISSION_CONFIG = {
     "job_submission_name": "",
     "job_submission_description": "TEST_DESC",
     "job_submission_owner_email": "",
-    "job_script": "",
+    "job_script_id": "",
 }
 
 JOBBERGATE_DEFAULT_DOTENV_PATH = Path("/etc/default/jobbergate-cli")

--- a/jobbergate-cli/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate-cli/jobbergate_cli/jobbergate_api_wrapper.py
@@ -554,7 +554,7 @@ class JobbergateApi:
             )
             application_id = app_data.get("id")
 
-        data["application"] = application_id
+        data["application_id"] = application_id
 
         if param_file:
             is_param_file = os.path.isfile(param_file)


### PR DESCRIPTION
#### What
Adjusted api call parameters

#### Why
The CLI was supplying "application" instead of "application_id", and the API wasn't happy about it.
