### PR TITLE
Fixed urls for client credentials login

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -7,6 +7,11 @@ This file keeps track of all notable changes to jobbergate-api
 Unreleased
 ----------
 
+2.2.9 -- 2022-02-16
+-------------------
+- Added AUTH0_LOGIN_DOMAIN setting in CLI
+- Adjusted auth workflow to prefer AUTH0_LOGIN_DOMAIN over AUTH0_DOMAIN in CLI
+
 2.2.8 -- 2022-02-15
 -------------------
 - Fixed job submission data format for creation POST request in CLI

--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -7,6 +7,11 @@ This file keeps track of all notable changes to jobbergate-cli
 Unreleased
 ----------
 
+2.2.9 -- 2022-02-16
+-------------------
+- Added AUTH0_LOGIN_DOMAIN setting
+- Adjusted auth workflow to prefer AUTH0_LOGIN_DOMAIN over AUTH0_DOMAIN
+
 2.2.8 -- 2022-02-15
 -------------------
 - Fixed job submission data format for creation POST request

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -40,6 +40,7 @@ class Settings(BaseSettings):
 
     # Auth0 config for machine-to-machine security
     AUTH0_DOMAIN: str
+    AUTH0_LOGIN_DOMAIN: Optional[str]
     AUTH0_AUDIENCE: str
     AUTH0_CLIENT_ID: str
     AUTH0_CLIENT_SECRET: str
@@ -68,6 +69,8 @@ class Settings(BaseSettings):
         values["JOBBERGATE_USER_TOKEN_DIR"] = token_dir
         values["JOBBERGATE_API_ACCESS_TOKEN_PATH"] = token_dir / "access.token"
         values["JOBBERGATE_API_REFRESH_TOKEN_PATH"] = token_dir / "refresh.token"
+
+        values.setdefault("AUTH0_LOGIN_DOMAIN", values["AUTH0_DOMAIN"])
 
         return values
 

--- a/jobbergate-cli/jobbergate_cli/main.py
+++ b/jobbergate-cli/jobbergate_cli/main.py
@@ -327,7 +327,7 @@ def refresh_access_token(refresh_token: str) -> str:
     :param refresh_token: The refresh token to be used to retrieve a new access token.
     :returns: The fetched access token.
     """
-    url = f"https://{settings.AUTH0_DOMAIN}/oauth/token"
+    url = f"https://{settings.AUTH0_LOGIN_DOMAIN}/oauth/token"
     logger.debug(f"Requesting refreshed access token from {url}")
     response = requests.post(
         url,
@@ -363,7 +363,7 @@ def fetch_auth_tokens() -> TokenSet:
 
     :returns: A TokenSet object carrying the fetched tokens.
     """
-    url = f"https://{settings.AUTH0_DOMAIN}/oauth/device/code"
+    url = f"https://{settings.AUTH0_LOGIN_DOMAIN}/oauth/device/code"
     response = requests.post(
         url,
         headers={"content-type": "application/x-www-form-urlencoded"},
@@ -401,7 +401,7 @@ def fetch_auth_tokens() -> TokenSet:
     attempt_count = 0
     while start_time + time_limit > datetime.now():
         attempt_count += 1
-        token_url = f"https://{settings.AUTH0_DOMAIN}/oauth/token"
+        token_url = f"https://{settings.AUTH0_LOGIN_DOMAIN}/oauth/token"
         token_response = requests.post(
             token_url,
             headers={"content-type": "application/x-www-form-urlencoded"},

--- a/jobbergate-cli/pyproject.toml
+++ b/jobbergate-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jobbergate-cli"
-version = "2.2.8"
+version = "2.2.9"
 description = "Jobbergate CLI Client"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
Added an AUTH0_LOGIN_DOMAIN setting to use for requests from jobbergate-cli

#### Why
We need to be able to use login.omnivector.solutions for login. This will probably change in the future to a more armada specific domain, so I made it an env setting that can be adjusted without a code change.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
