### PR TITLE
Tucker/armada 501  add cluster name to cli

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -299,6 +299,7 @@ async def job_submission_agent_update(
     """
     identity_claims = IdentityClaims.from_token_payload(token_payload)
     if identity_claims.cluster_id is None:
+        logger.error("Access token  does not contain a cluster_id")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Access token does not contain a `cluster_id`. Cannot update job_submission",
@@ -348,6 +349,7 @@ async def job_submissions_agent_active(
     """
     identity_claims = IdentityClaims.from_token_payload(token_payload)
     if identity_claims.cluster_id is None:
+        logger.error("Access token  does not contain a cluster_id")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Access token does not contain a `cluster_id`. Cannot fetch pending submissions",

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -299,7 +299,7 @@ async def job_submission_agent_update(
     """
     identity_claims = IdentityClaims.from_token_payload(token_payload)
     if identity_claims.cluster_id is None:
-        logger.error("Access token  does not contain a cluster_id")
+        logger.error("Access token does not contain a cluster_id")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Access token does not contain a `cluster_id`. Cannot update job_submission",
@@ -349,7 +349,7 @@ async def job_submissions_agent_active(
     """
     identity_claims = IdentityClaims.from_token_payload(token_payload)
     if identity_claims.cluster_id is None:
-        logger.error("Access token  does not contain a cluster_id")
+        logger.error("Access token does not contain a cluster_id")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Access token does not contain a `cluster_id`. Cannot fetch pending submissions",

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -154,6 +154,7 @@ class JobSubmissionCreateRequestData(pydantic.BaseModel):
     job_submission_name: str
     job_submission_description: Optional[str] = None
     job_script_id: int
+    cluster_id: Optional[str] = None
     execution_directory: Optional[Path] = None
 
 

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -44,6 +44,11 @@ def create(
         ...,
         help="The id of the job_script from which to create the job submission",
     ),
+    cluster_id: str = typer.Option(
+        None,
+        "--cluster-name",
+        help="The name of the cluster where the job should be submitted (i.g. 'nash-staging')",
+    ),
     execution_directory: Optional[Path] = typer.Option(
         None,
         help="""
@@ -68,6 +73,7 @@ def create(
         name,
         description=description,
         execution_directory=execution_directory,
+        cluster_id=cluster_id,
     )
     render_single_result(
         jg_ctx,

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/tools.py
@@ -25,7 +25,7 @@ def create_job_submission(
     :param: job_script_id:       The ``id`` of the Job Script to submit to Slurm
     :param: name:                The name to attach to the Job Submission
     :param: description:         An optional description that may be added to the Job Submission
-    :param: execution_directory: An optional cluster_id for the cluster where the job should be executed,
+    :param: cluster_id:          An optional cluster_id for the cluster where the job should be executed,
                                  if left off, it will default to the current cluster.
     :param: execution_directory: An optional directory where the job should be executed. If provided as a relative path,
                                  it will be constructed as an absolute path relative to the current working directory.

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/tools.py
@@ -14,6 +14,7 @@ def create_job_submission(
     job_script_id: int,
     name: str,
     description: Optional[str] = None,
+    cluster_id: Optional[str] = None,
     execution_directory: Optional[Path] = None,
 ) -> JobSubmissionResponse:
     """
@@ -24,6 +25,8 @@ def create_job_submission(
     :param: job_script_id:       The ``id`` of the Job Script to submit to Slurm
     :param: name:                The name to attach to the Job Submission
     :param: description:         An optional description that may be added to the Job Submission
+    :param: execution_directory: An optional cluster_id for the cluster where the job should be executed,
+                                 if left off, it will default to the current cluster.
     :param: execution_directory: An optional directory where the job should be executed. If provided as a relative path,
                                  it will be constructed as an absolute path relative to the current working directory.
     :returns: The Job Submission data returned by the API after creating the new Job Submission
@@ -37,6 +40,7 @@ def create_job_submission(
         job_submission_name=name,
         job_submission_description=description,
         job_script_id=job_script_id,
+        cluster_id=cluster_id,
     )
 
     if execution_directory is not None:

--- a/jobbergate-cli/tests/subapps/job_submissions/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_tools.py
@@ -93,6 +93,50 @@ def test_create_job_submission__with_execution_dir(
     assert payload["execution_directory"] is None
 
 
+def test_create_job_submission__with_cluster_id(
+    respx_mock,
+    dummy_job_submission_data,
+    dummy_domain,
+    dummy_context,
+    attach_persona,
+):
+    job_submission_data = dummy_job_submission_data[0]
+    job_submission_name = job_submission_data["job_submission_name"]
+    job_submission_description = job_submission_data["job_submission_description"]
+
+    job_script_id = job_submission_data["job_script_id"]
+
+    create_job_submission_route = respx_mock.post(f"{dummy_domain}/job-submissions")
+    create_job_submission_route.mock(
+        return_value=httpx.Response(
+            httpx.codes.CREATED,
+            json=job_submission_data,
+        ),
+    )
+
+    attach_persona("dummy@dummy.com")
+
+    create_job_submission(
+        dummy_context,
+        job_script_id,
+        job_submission_name,
+        job_submission_description,
+        cluster_id="dummy-cluster",
+    )
+    payload = json.loads(create_job_submission_route.calls.last.request.content)
+    assert payload["cluster_id"] == "dummy-cluster"
+
+    create_job_submission(
+        dummy_context,
+        job_script_id,
+        job_submission_name,
+        job_submission_description,
+        cluster_id=None,
+    )
+    payload = json.loads(create_job_submission_route.calls.last.request.content)
+    assert payload["cluster_id"] is None
+
+
 def test_fetch_job_submission_data__success__using_id(
     respx_mock,
     dummy_context,


### PR DESCRIPTION
#### What
Added a `--cluster-name` option to the jobbergate-cli for job-submissions

#### Why
Users need to be able to override which cluster the job will execute on.

`Task`: https://app.clickup.com/t/18022949/ARMADA-501

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
