### PR TITLE
ARMADA-517 Added graceful handling of pyperclip exceptions

### DIFF
--- a/jobbergate-cli/jobbergate_cli/main.py
+++ b/jobbergate-cli/jobbergate_cli/main.py
@@ -7,7 +7,6 @@ from typing import Optional
 import httpx
 import importlib_metadata
 import jose
-import pyperclip
 import typer
 
 from jobbergate_cli.auth import clear_token_cache, fetch_auth_tokens, init_persona, load_tokens_from_cache
@@ -16,7 +15,7 @@ from jobbergate_cli.exceptions import Abort, handle_abort
 from jobbergate_cli.logging import init_logs, init_sentry
 from jobbergate_cli.render import render_json, terminal_message
 from jobbergate_cli.schemas import JobbergateContext, Persona, TokenSet
-from jobbergate_cli.text_tools import conjoin
+from jobbergate_cli.text_tools import conjoin, copy_to_clipboard
 
 
 app = typer.Typer()
@@ -199,13 +198,13 @@ def show_token(
         prefix = "Bearer " if show_prefix else ""
         token_text = f"{prefix}{token}"
 
-    pyperclip.copy(token_text)
+    on_clipboard = copy_to_clipboard(token_text)
+
     if plain:
         print(token_text)
     else:
-        terminal_message(
-            token_text,
-            subject=subject,
-            footer="The output was copied to your clipboard",
-            indent=False,
-        )
+        kwargs = dict(subject=subject, indent=False)
+        if on_clipboard:
+            kwargs["footer"] = "The output was copied to your clipboard"
+
+        terminal_message(token_text, **kwargs)

--- a/jobbergate-cli/jobbergate_cli/text_tools.py
+++ b/jobbergate-cli/jobbergate_cli/text_tools.py
@@ -4,6 +4,8 @@ Provide some basic tools for manipulating text.
 
 import textwrap
 
+import pyperclip
+
 
 def dedent(text: str) -> str:
     """
@@ -42,3 +44,16 @@ def indent(text: str, prefix: str = "    ", **kwargs) -> str:
     Simple wrapper for the textwrap.indent() method but includes a default prefix.
     """
     return textwrap.indent(text, prefix=prefix, **kwargs)
+
+
+def copy_to_clipboard(text: str) -> bool:
+    """
+    Copy the provided text to the clipboard.
+
+    If the clipboard is not available, return False. Otherwise, return True.
+    """
+    try:
+        pyperclip.copy(text)
+        return True
+    except Exception:
+        return False

--- a/jobbergate-cli/tests/test_text_tools.py
+++ b/jobbergate-cli/tests/test_text_tools.py
@@ -1,0 +1,19 @@
+from jobbergate_cli.text_tools import copy_to_clipboard
+
+
+def test_copy_to_clipboard__success(mocker):
+    """
+    Validate that the ``copy_to_clipboard`` function calls ``pyperclip.copy`` successfully and returns ``True``.
+    """
+    mocked_copy = mocker.patch("pyperclip.copy")
+    assert copy_to_clipboard("some text")
+    mocked_copy.assert_called_once_with("some text")
+
+
+def test_copy_to_clipboard__does_not_raise_exception_on_failure(mocker):
+    """
+    Validate that the ``copy_to_clipboard`` function catches exceptions from ``pyperclip.copy`` and returns ``False``.
+    """
+    mocked_copy = mocker.patch("pyperclip.copy", side_effect=RuntimeError("BOOM!!!"))
+    assert not copy_to_clipboard("some text")
+    mocked_copy.assert_called_once_with("some text")


### PR DESCRIPTION
#### What
Absorbs exceptions from pyperclip gracefully.

#### Why
The ability to copy tokens to the clipboard is very nice, but it breaks when the system does not have a clipboard set up. This absorbs the exception without removing pyperclip.

`Task`: https://app.clickup.com/t/18022949/ARMADA-517

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
