### PR TITLE
ARMADA-542

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -10,6 +10,7 @@ Unreleased
 3.1.0 -- 2022-04-20
 -------------------
 - Added execution_directory to job submissions
+- Added checks for empty cached token files
 
 3.0.4 -- 2022-04-11
 -------------------

--- a/jobbergate-cli/jobbergate_cli/auth.py
+++ b/jobbergate-cli/jobbergate_cli/auth.py
@@ -24,13 +24,30 @@ def validate_token_and_extract_identity(token_set: TokenSet) -> IdentityData:
     Validate the access_token from a TokenSet and extract the identity data.
 
     Validations:
+        * Checks if access_token is not empty.
         * Checks timestamp on the access token.
-        * Checks for identity data
-        * Checks that all identity elements are present
+        * Checks for identity data.
+        * Checks that all identity elements are present.
 
-    Reports an error in the logs and to the user if there is an issue with the access_token
+    Reports an error in the logs and to the user if there is an issue with the access_token.
     """
     logger.debug("Validating access token")
+
+    token_is_empty = not token_set.access_token
+    if token_is_empty:
+        logger.debug("Access token exists but it is empty")
+        raise Abort(
+            """
+            Access token exists but it is empty.
+
+            Please try logging in again.
+            """,
+            subject="Empty access token",
+            support=True,
+            log_message="Empty access access token",
+            sentry_context=dict(access_token=dict(access_token=token_set.access_token)),
+        )
+
     try:
         token_data = jwt.decode(
             token_set.access_token,

--- a/jobbergate-cli/jobbergate_cli/auth.py
+++ b/jobbergate-cli/jobbergate_cli/auth.py
@@ -33,18 +33,18 @@ def validate_token_and_extract_identity(token_set: TokenSet) -> IdentityData:
     """
     logger.debug("Validating access token")
 
-    token_is_empty = not token_set.access_token
-    if token_is_empty:
-        logger.debug("Access token exists but it is empty")
+    token_file_is_empty = not token_set.access_token
+    if token_file_is_empty:
+        logger.debug("Access token file exists but it is empty")
         raise Abort(
             """
-            Access token exists but it is empty.
+            Access token file exists but it is empty.
 
             Please try logging in again.
             """,
-            subject="Empty access token",
+            subject="Empty access token file",
             support=True,
-            log_message="Empty access access token",
+            log_message="Empty access token file",
             sentry_context=dict(access_token=dict(access_token=token_set.access_token)),
         )
 

--- a/jobbergate-cli/tests/test_auth.py
+++ b/jobbergate-cli/tests/test_auth.py
@@ -96,6 +96,16 @@ def test_validate_token_and_extract_identity__re_raises_ExpiredSignatureError(ma
             validate_token_and_extract_identity(TokenSet(access_token=access_token))
 
 
+def test_validate_token_and_extract_identity__raises_abort_on_empty_token():
+    """
+    Validate that the ``validate_token_and_extract_identity()`` function will
+    raise an ``Abort`` when the access_token exists but is an empty string/file.
+    """
+    test_token_set = TokenSet(access_token="")
+    with pytest.raises(Abort, match="Access token exists but it is empty"):
+        validate_token_and_extract_identity(test_token_set)
+
+
 def test_validate_token_and_extract_identity__raises_abort_on_unknown_error(mocker):
     """
     Validate that the ``validate_token_and_extract_identity()`` function will raise an ``Abort`` when the

--- a/jobbergate-cli/tests/test_auth.py
+++ b/jobbergate-cli/tests/test_auth.py
@@ -102,7 +102,7 @@ def test_validate_token_and_extract_identity__raises_abort_on_empty_token():
     raise an ``Abort`` when the access_token exists but is an empty string/file.
     """
     test_token_set = TokenSet(access_token="")
-    with pytest.raises(Abort, match="Access token exists but it is empty"):
+    with pytest.raises(Abort, match="Access token file exists but it is empty"):
         validate_token_and_extract_identity(test_token_set)
 
 


### PR DESCRIPTION
#### What

Add a warning informing the users to login again when the access token is empty.

#### Why

A user ended up with an empty token file in `~/.local/share/jobbergate/token`. As a result, the jobbergate command did nothing. No error message unless the `--verbose` flag was set, just back to the prompt with no visible effect.
The blank token was several hours old, so the content check takes prio over the token's age check.

`Task`: https://app.clickup.com/t/18022949/ARMADA-542

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
