### PR TITLE
Making file lister case-insensitive

### DIFF
--- a/jobbergate-cli/jobbergate_cli/subapps/applications/application_helpers.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/application_helpers.py
@@ -4,7 +4,7 @@ Helper functions that may be used inside of Jobbergate applications.
 import shlex
 import subprocess
 from getpass import getuser
-from pathlib import Path
+import os, re, fnmatch
 
 
 def get_running_jobs(user_only=True):
@@ -27,11 +27,11 @@ def get_running_jobs(user_only=True):
     return ID_alternatives
 
 
-def get_file_list(path=None, search_term="*.*"):
+def get_file_list(path=".", search_term="*.*"):
     """Returns a list of input files in a directory ( default: pwd)."""
-    if not path:
-        path = Path.cwd()
+    all_paths = os.listdir(path)
+    pattern = re.compile(fnmatch.translate(search_term), re.IGNORECASE)
 
-    file_paths = sorted(path.glob(search_term), key=lambda p: p.stat().st_mtime, reverse=True)
-    file_names = [f.name for f in file_paths if f.is_file()]
-    return file_names
+    file_paths = [p for p in all_paths if os.path.isfile(os.path.join(path, p)) and re.match(pattern, p)]
+    file_paths = sorted(file_paths, key=lambda p: os.stat(os.path.join(path, p)).st_mtime, reverse=True)
+    return file_paths

--- a/jobbergate-cli/tests/subapps/applications/test_application_helpers.py
+++ b/jobbergate-cli/tests/subapps/applications/test_application_helpers.py
@@ -57,17 +57,18 @@ def test_get_running_jobs(mocker):
     assert get_running_jobs() == []
 
 
-def test_get_file_list(tmp_path, temp_cd):
+def test_get_file_list__basic(tmp_path, temp_cd):
     """
     Test that the ``get_file_list()`` method returns a list of files in a path matching some search term.
 
     Assert that the function works with no arguments, with only the target path, and with the search term.
+    Also assert that case is ignored.
     """
     file1 = tmp_path / "file1.py"
     file1.write_text("foo")
     os.utime(file1, (0, 2))
 
-    file2 = tmp_path / "file2.txt"
+    file2 = tmp_path / "FILE2.txt"
     file2.write_text("bar")
     os.utime(file2, (0, 3))
 
@@ -80,22 +81,25 @@ def test_get_file_list(tmp_path, temp_cd):
 
     with temp_cd(tmp_path):
         assert get_file_list() == [
-            "file2.txt",
+            "FILE2.txt",
             "file1.py",
         ]
 
     assert get_file_list(tmp_path) == [
-        "file2.txt",
+        "FILE2.txt",
         "file1.py",
     ]
 
-    assert get_file_list(tmp_path, search_term="**/*") == [
-        "file2.txt",
+    assert get_file_list(tmp_path, search_term="*") == [
+        "FILE2.txt",
         "file1.py",
-        "file3.py",
     ]
 
-    assert get_file_list(tmp_path, search_term="**/*.py") == [
+    assert get_file_list(tmp_path, search_term="*.py") == [
         "file1.py",
-        "file3.py",
+    ]
+
+    assert get_file_list(tmp_path, search_term="*FILE*") == [
+        "FILE2.txt",
+        "file1.py",
     ]


### PR DESCRIPTION
#### What
Makes the helper function get_file_list ignore case when searching for files. 
Could (maybe should?) be made optional to not change function of existing applications. Only difference should be the flag in re.compile: 0 vs re.IGNORECASE.

#### Why
More flexible searching.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
