### PR TITLE
Bumped CHANGELOG and versions for release

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,9 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+
+3.1.1 -- 2022-06-01
+-------------------
 - Removed AWS settings. Boto3 supports these env variables natively.
 
 3.1.0 -- 2022-04-20

--- a/jobbergate-api/pyproject.toml
+++ b/jobbergate-api/pyproject.toml
@@ -3,7 +3,7 @@ authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 name = "jobbergate-api"
 description = "Jobbergate API"
 license = "MIT"
-version = "3.1.0-alpha.1"
+version = "3.1.1"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -7,6 +7,10 @@ This file keeps track of all notable changes to jobbergate-cli
 Unreleased
 ----------
 
+3.1.1 -- 2022-06-01
+-------------------
+- Added warning and handling for empty access tokens in the cache.
+
 3.1.0 -- 2022-04-20
 -------------------
 - Added execution_directory to job submissions

--- a/jobbergate-cli/pyproject.toml
+++ b/jobbergate-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jobbergate-cli"
-version = "3.1.0"
+version = "3.1.1"
 description = "Jobbergate CLI Client"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
Bumped CHANGELOG and package versions to 3.1.1.

#### Why
Because we are about to release them.


---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
