### PR TITLE
Set `environment` variable when Sentry initializes

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to jobbergate-cli
 Unreleased
 ----------
 
+- Set ``environment`` variable for Sentry based on settings parameter.
+
 3.1.1 -- 2022-06-01
 -------------------
 - Added warning and handling for empty access tokens in the cache.

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     # enable http tracing
     JOBBERGATE_DEBUG: bool = Field(False)
 
+    # Setry's configuration
     SENTRY_DSN: Optional[str]
     SENTRY_TRACE_RATE: float = Field(1.0, gt=0.0, le=1.0)
     SENTRY_ENV: str = "local"

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
 
     SENTRY_DSN: Optional[str]
     SENTRY_TRACE_RATE: float = Field(1.0, gt=0.0, le=1.0)
+    SENTRY_ENV: str = "local"
 
     # Settings for log uploads
     JOBBERGATE_AWS_ACCESS_KEY_ID: Optional[str]

--- a/jobbergate-cli/jobbergate_cli/logging.py
+++ b/jobbergate-cli/jobbergate_cli/logging.py
@@ -39,4 +39,5 @@ def init_sentry():
         sentry_sdk.init(
             dsn=settings.SENTRY_DSN,
             traces_sample_rate=settings.SENTRY_TRACE_RATE,
+            environment=settings.SENTRY_ENV,
         )


### PR DESCRIPTION
#### What
This PR only adds a parameter to the settings class and use it as Sentry's environment variable

#### Why
Needed to better organize Sentry

`Task`: https://app.clickup.com/t/18022949/ARMADA-528

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
