### PR TITLE
Armada 617 add documentation for how the buckets that jobbergate uses are organized

### DIFF
--- a/jobbergate-docs/src/implementation_details.rst
+++ b/jobbergate-docs/src/implementation_details.rst
@@ -1,0 +1,27 @@
+=======================
+Implementations Details
+=======================
+
+Jobbergate-API
+==============
+
+Storage
+-------
+
+Besides the information keept in the database, application and job-scripts files are stored on a S3 Bucket as tarfiles and text files, respectively.
+The bucket name is ``jobbergate-staging-eu-north-1-resources`` by default, but it can be changed using the configuration ``S3_BUCKET_NAME``.
+The files are arranged in a directory for each, followed in the next level by the ``id`` number, and finally the filename (``jobbergate.tar.gz`` for applications and ``jobbergate.txt``). See the example:
+
+::
+
+    <S3_BUCKET_NAME>
+    ├── applications
+    │   ├── 1
+    │   │   └── jobbergate.tar.gz
+    │   └── 2
+    │       └── jobbergate.tar.gz
+    └── job-scripts
+        ├── 1
+        │   └── jobbergate.txt
+        └── 2
+            └── jobbergate.txt

--- a/jobbergate-docs/src/implementation_details.rst
+++ b/jobbergate-docs/src/implementation_details.rst
@@ -8,9 +8,9 @@ Jobbergate-API
 Storage
 -------
 
-Besides the information keept in the database, application and job-scripts files are stored on a S3 Bucket as tarfiles and text files, respectively.
-The bucket name is ``jobbergate-staging-eu-north-1-resources`` by default, but it can be changed using the configuration ``S3_BUCKET_NAME``.
-The files are arranged in a directory for each, followed in the next level by the ``id`` number, and finally the filename (``jobbergate.tar.gz`` for applications and ``jobbergate.txt``). See the example:
+Besides the information kept in the database, application and job-scripts files are stored on a S3 Bucket as tarfiles and text files, respectively.
+The bucket is named ``jobbergate-staging-eu-north-1-resources`` by default, but it can be changed using the configuration ``S3_BUCKET_NAME``.
+The files are arranged in a directory for each, followed in the next level by the ``id`` number, and finally the filename (``jobbergate.tar.gz`` for applications and ``jobbergate.txt`` for job-scripts). See the example:
 
 ::
 

--- a/jobbergate-docs/src/index.rst
+++ b/jobbergate-docs/src/index.rst
@@ -15,3 +15,4 @@ Table of Contents
    Overview <overview>
    Usage <usage>
    Jobbergate.yaml <jobbergate_yaml>
+   Implementation Details <implementation_details>

--- a/jobbergate-docs/src/overview.rst
+++ b/jobbergate-docs/src/overview.rst
@@ -66,7 +66,7 @@ API that serves as the back-end for the system. It is interacted with via the CL
 can be dispatched to it from any other web application.
 
 There jobbergate-api offers `interactive documentation via swagger
-<https://jobbergateapi2-staging.omnivector.solutions/docs>`_
+<https://jobbergateapi2-staging.omnivector.solutions/docs>`_.
 
 Requests to the API must be accompanied by a JWT issued by a POST request to the ``/api-auth-token``
 endpoint.


### PR DESCRIPTION
#### What
Describe implementation details about the arrangement of applications and job-scripts files on an S3 bucket.

#### Why
We need to have some documentation that explains the layout in S3.

`Task`: https://app.clickup.com/t/18022949/ARMADA-617

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
