### PR TITLE
ARMADA-652 Application config overrides user supplied values

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -144,6 +144,13 @@ async def job_script_create(
             detail=f"Application with id={job_script.application_id} not found.",
         )
     application = ApplicationResponse.parse_obj(raw_application)
+
+    if application.application_uploaded is False:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Application with id={job_script.application_id} was not uploaded.",
+        )
+
     logger.debug("Fetching application tarfile")
     s3_application_tar = get_s3_object_as_tarfile(s3man_applications, application.id)
 


### PR DESCRIPTION
#### What
Fix the creation of job scripts when the base application is marked as not uploaded. It now raises an error.

#### Why
The application files at S3 and the database columns `application_config` and `application_file` can get out-sync sometimes, producing unexpected behaviors. For instance, the issue described in the task below:

`Task`: https://app.clickup.com/t/18022949/ARMADA-652

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
