### PR TITLE
ARMADA-747 Fix api not sending job script files

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Fix API was not sending job-script files to the agent.
 
 3.2.3 -- 2022-08-01
 -------------------

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -316,13 +316,22 @@ async def job_submissions_agent_pending(
     logger.trace(f"query = {render_sql(query)}")
     rows = await database.fetch_all(query)
 
-    response = [
-        PendingJobSubmission(
-            **row,
-            job_script_data_as_string=s3man_jobscripts[row.job_script_id],
+    try:
+        response = [
+            PendingJobSubmission(
+                **row,
+                job_script_data_as_string=s3man_jobscripts[str(row.get("job_script_id"))],
+            )
+            for row in rows
+        ]
+    except KeyError:
+        message = "JobScript file not found."
+        logger.warning(message)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=message,
         )
-        for row in rows
-    ]
+
     return response
 
 

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -325,8 +325,10 @@ async def job_submissions_agent_pending(
             for row in rows
         ]
     except KeyError:
-        message = "JobScript file not found."
-        logger.warning(message)
+        list_ids = (str(row.get("job_script_id")) for row in rows)
+        missing_ids = {id for id in list_ids if id not in s3man_jobscripts}
+        message = f"JobScript file(s) not found, the missing ids are: {', '.join(missing_ids)}"
+        logger.error(message)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=message,

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -126,6 +126,7 @@ class PendingJobSubmission(BaseModel, extra=Extra.ignore):
     job_submission_owner_email: str
     execution_directory: Optional[Path]
     job_script_name: str
+    job_script_data_as_string: str
     application_name: str
 
 

--- a/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
@@ -1307,7 +1307,7 @@ async def test_job_submissions_agent_pending__success(
     making the request. We show this by asserting that the job_submissions returned in the response are
     only job_submissions with a ``client_id`` that matches the ``client_id`` found in the request's
     token payload. We also make sure that the response includes job_script_data_as_string,
-    it is fundamental for the integration with the agent.
+    as it is fundamental for the integration with the agent.
     """
     inserted_application_id = await database.execute(
         query=applications_table.insert(),

--- a/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
@@ -1363,7 +1363,7 @@ async def test_job_submissions_agent_pending__success(
     )
     with mock.patch(
         "jobbergate_api.apps.job_submissions.routers.s3man_jobscripts",
-        {inserted_job_script_id: DUMMY_JOB_SCRIPT},
+        {str(inserted_job_script_id): DUMMY_JOB_SCRIPT},
     ):
         response = await client.get("/jobbergate/job-submissions/agent/pending")
 


### PR DESCRIPTION
#### What
A bug was identified after moving the job-script files to S3 (PR #111).

#### Why
As one can see at Jobbergate's source code, the response model for [PendingJobSubmission](https://github.com/omnivector-solutions/jobbergate/blob/3b452eec5fcc6dd5aa33f5907d9f4e13bc1d730a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py#L117) does not include the field job_script_data_as_string  anymore. [Cluster-agent](https://github.com/omnivector-solutions/cluster-agent/blob/6b0f576df01f56043dd1df822ae89d314fbaaf99/cluster_agent/jobbergate/schemas.py#L7), of course, expects for it, resulting in an error.

`Task`: https://app.clickup.com/t/18022949/ARMADA-747

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
