### PR TITLE
Patch application files

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/applications/application_files.py
+++ b/jobbergate-api/jobbergate_api/apps/applications/application_files.py
@@ -76,8 +76,11 @@ class ApplicationFiles(BaseModel):
         """
         Delete the files associated with the given id.
         """
-        logger.debug(f"Deleting from S3 the files associated to {application_id=}")
         file_manager = cls.file_manager_factory(application_id)
+        logger.debug(
+            f"Deleting from S3 the files associated to {application_id=}."
+            f"Files to be deleted: {', '.join(map(str, file_manager.keys()))}"
+        )
         file_manager.clear()
         logger.debug(f"Files were deleted for {application_id=}")
 

--- a/jobbergate-api/jobbergate_api/apps/applications/application_files.py
+++ b/jobbergate-api/jobbergate_api/apps/applications/application_files.py
@@ -78,7 +78,7 @@ class ApplicationFiles(BaseModel):
         """
         file_manager = cls.file_manager_factory(application_id)
         logger.debug(
-            f"Deleting from S3 the files associated to {application_id=}."
+            f"Deleting from S3 the files associated to {application_id=}. "
             f"Files to be deleted: {', '.join(map(str, file_manager.keys()))}"
         )
         file_manager.clear()

--- a/jobbergate-api/jobbergate_api/apps/applications/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/applications/routers.py
@@ -288,7 +288,7 @@ async def applications_get_by_id(application_id: int = Query(...)):
     if application_data["application_uploaded"]:
         response = ApplicationResponse(
             **application_data,
-            **ApplicationFiles.get_from_s3(application_data["id"]).dict(
+            **ApplicationFiles.get_from_s3(application_id).dict(
                 by_alias=True,
                 exclude_defaults=True,
                 exclude_unset=True,

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/job_script_files.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/job_script_files.py
@@ -185,8 +185,11 @@ class JobScriptFiles(BaseModel):
         """
         Delete the files associated with the given id.
         """
-        logger.debug(f"Deleting from S3 the files associated to {job_script_id=}")
         file_manager = cls.file_manager_factory(job_script_id)
+        logger.debug(
+            f"Deleting from S3 the files associated to {job_script_id=}. "
+            f"Files to be deleted: {', '.join(map(str, file_manager.keys()))}"
+        )
         file_manager.clear()
         logger.debug(f"Files were deleted for {job_script_id=}")
 

--- a/jobbergate-api/jobbergate_api/email_notification.py
+++ b/jobbergate-api/jobbergate_api/email_notification.py
@@ -35,13 +35,12 @@ class EmailManager:
         """
         Send an email using this manager.
         """
-        message = self._build_message(to_emails, subject, **kwargs)
-
         with EmailNotificationError.handle_errors(
             f"Error while sending email from_email={self.from_email}, {to_emails=}",
             do_except=lambda params: logger.warning(params.final_message),
             re_raise=not skip_on_failure,
         ):
+            message = self._build_message(to_emails, subject, **kwargs)
             self.email_client.send(message)
 
     def _build_message(self, to_emails: Union[str, List[str]], subject: str, **kwargs) -> Mail:

--- a/jobbergate-api/jobbergate_api/tests/apps/applications/test_application_files.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/applications/test_application_files.py
@@ -276,7 +276,7 @@ class TestApplicationFiles:
         ApplicationFiles.delete_from_s3(another_application_id)
 
         deleted_application_files = ApplicationFiles.get_from_s3(another_application_id)
-        assert deleted_application_files.dict(exclude_unset=True, exclude_defaults=True) == {}
+        assert deleted_application_files.dict(exclude_unset=True, exclude_defaults=True) == {"templates": {}}
 
         actual_application_files = ApplicationFiles.get_from_s3(remaining_application_id)
         assert desired_application_files == actual_application_files

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
@@ -38,8 +38,7 @@ def fetch_application_data(
     :param: identifier: If supplied, look for an application instance with the provided identifier
     :returns: An instance of ApplicationResponse containing the application data
     """
-    url = f"/jobbergate/applications/{id}"
-    params = dict()
+    identification = id
     if id is None and identifier is None:
         raise Abort(
             """
@@ -57,8 +56,7 @@ def fetch_application_data(
             warn_only=True,
         )
     elif identifier is not None:
-        url = "/jobbergate/applications"
-        params["identifier"] = identifier
+        identification = identifier
 
     # Make static type checkers happy
     assert jg_ctx.client is not None
@@ -68,13 +66,12 @@ def fetch_application_data(
         ApplicationResponse,
         make_request(
             jg_ctx.client,
-            url,
+            f"/jobbergate/applications/{identification}",
             "GET",
             expected_status=200,
             abort_message=f"Couldn't retrieve application {stub} from API",
             response_model_cls=ApplicationResponse,
             support=True,
-            params=params,
         ),
     )
 

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
@@ -38,7 +38,7 @@ def fetch_application_data(
     :param: identifier: If supplied, look for an application instance with the provided identifier
     :returns: An instance of ApplicationResponse containing the application data
     """
-    identification = id
+    identification: Any = id
     if id is None and identifier is None:
         raise Abort(
             """

--- a/jobbergate-cli/tests/subapps/applications/test_app.py
+++ b/jobbergate-cli/tests/subapps/applications/test_app.py
@@ -87,7 +87,7 @@ def test_get_one__success__using_identifier(
     cli_runner,
     mocker,
 ):
-    respx_mock.get(f"{dummy_domain}/jobbergate/applications?identifier=dummy").mock(
+    respx_mock.get(f"{dummy_domain}/jobbergate/applications/dummy").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json=dummy_application_data[0],

--- a/jobbergate-cli/tests/subapps/applications/test_tools.py
+++ b/jobbergate-cli/tests/subapps/applications/test_tools.py
@@ -66,7 +66,7 @@ def test_fetch_application_data__success__using_identifier(
 ):
     app_data = dummy_application_data[0]
     app_identifier = app_data["application_identifier"]
-    fetch_route = respx_mock.get(f"{dummy_domain}/jobbergate/applications?identifier={app_identifier}")
+    fetch_route = respx_mock.get(f"{dummy_domain}/jobbergate/applications/{app_identifier}")
     fetch_route.mock(
         return_value=httpx.Response(
             httpx.codes.OK,


### PR DESCRIPTION
#### What

* Template files were not included in the response of get_application_by_id;
* One call at the email notification system was not inside the error handler, resulting in an error when from_email was not defined on the configuration file;
* The CLI relies on the `application_list` endpoint to select one by identifier, but this endpoint does not return the application files anymore. It should call get_application_by_id  instead.
* Jobbergate was not receiving the report_message from cluster-agent when a job submission was rejected;
* A few improvements on log messages.

#### Why

A detailed round of tests and fixes for the new release.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
