### PR TITLE
fix poetry version on prepare_release.yaml

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -35,6 +35,8 @@ jobs:
           python-version: 3.8.10
 
       - uses: Gr1N/setup-poetry@v7
+        with:
+          poetry-version: 1.1.14
 
       - id: api-package
         name: Bump version on the API


### PR DESCRIPTION
#### What
Fix poetry version on [prepare_release.yaml](.github/workflows/prepare_release.yaml).

#### Why

Poetry changed the way the prereleases are named on its more recent version, so this PR fixes poetry at `1.1.14` to keep the previous behavior and to keep our workflows working.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
