### PR TITLE
ARMADA-794 - The --param-file argument asks for YAML, expects JSON

### DIFF
--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -136,7 +136,7 @@ def create(
         None,
         help=dedent(
             """
-            Supply a yaml file that contains the parameters for populating templates.
+            Supply a json file that contains the parameters for populating templates.
             If this is not supplied, the question asking in the application is triggered.
             """
         ),


### PR DESCRIPTION
#### What
Fix the helping message of `jobbergate job-scripts create`.

#### Why
When using the --param-file argument to create a Job Script from an application, the --help text says to supply a YAML file. However, the code expects a JSON file.

`Task`: https://app.clickup.com/t/18022949/ARMADA-794

**Note**: I intended to create new tests to cover the issue, but the previous tests were already prepared for JSON files. In this way, the task involved just the fix on the helping message.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
