### PR TITLE
ARMADA-811 Fixed sort order for enum columns

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -11,6 +11,7 @@ Unreleased
 - Changed default log level to DEBUG instead of INFO
 - Added ARMASEC_USE_HTTPS setting to allow non-https OIDC providers
 - Added better logging and reporting for pydantic validation errors
+- Fixed sorting in job_submissiosn.status
 
 3.2.5-alpha.0 -- 2022-09-15
 ---------------------------

--- a/jobbergate-api/jobbergate_api/storage.py
+++ b/jobbergate-api/jobbergate_api/storage.py
@@ -14,7 +14,7 @@ from asyncpg.exceptions import UniqueViolationError
 from fastapi.exceptions import HTTPException
 from loguru import logger
 from sqlalchemy import Column, or_
-from sqlalchemy.sql.expression import BooleanClauseList, UnaryExpression, Case
+from sqlalchemy.sql.expression import BooleanClauseList, Case, UnaryExpression
 from starlette import status
 from yarl import URL
 

--- a/jobbergate-api/jobbergate_api/storage.py
+++ b/jobbergate-api/jobbergate_api/storage.py
@@ -13,7 +13,7 @@ import sqlalchemy
 from asyncpg.exceptions import UniqueViolationError
 from fastapi.exceptions import HTTPException
 from loguru import logger
-from sqlalchemy import Column, or_
+from sqlalchemy import Column, Enum, or_
 from sqlalchemy.sql.expression import BooleanClauseList, Case, UnaryExpression
 from starlette import status
 from yarl import URL
@@ -81,6 +81,7 @@ def _build_enum_sort_clause(sort_column: Column, sort_ascending: bool) -> Case:
 
     To understand this more fully, start with this SO question: https://stackoverflow.com/a/23618085/642511
     """
+    assert isinstance(sort_column.type, Enum)
     sorted_values = sorted(sort_column.type.enums)
     sort_tuple = zip(sorted_values, sorted_values if sort_ascending else reversed(sorted_values))
     return sqlalchemy.case(dict(sort_tuple), value=sort_column)

--- a/jobbergate-api/jobbergate_api/storage.py
+++ b/jobbergate-api/jobbergate_api/storage.py
@@ -105,7 +105,7 @@ def sort_clause(
         )
     sort_column: typing.Union[Column, UnaryExpression, Case] = sortable_fields[index]
     if isinstance(sort_column, Column) and isinstance(sort_column.type, sqlalchemy.Enum):
-        sort_column = _build_enum_sort_clause(typing.cast(Column, sort_column), sort_ascending)
+        sort_column = _build_enum_sort_clause(sort_column, sort_ascending)
     elif not sort_ascending:
         sort_column = sort_column.desc()
     return sort_column

--- a/jobbergate-api/jobbergate_api/storage.py
+++ b/jobbergate-api/jobbergate_api/storage.py
@@ -83,7 +83,7 @@ def sort_clause(
         )
     sort_column: typing.Union[Column, UnaryExpression, Case] = sortable_fields[index]
     if isinstance(sort_column.type, sqlalchemy.Enum):
-        # SQLAlchemy will not sort enums alphabetically be default, but rather by creation order.
+        # SQLAlchemy will not sort enums alphabetically by default, but rather by creation order.
         # Thus, we have to force alphabetical sorting using a CASE clause.
         # The logic here is pretty insane. Basically, we have to provide a lookup and then a string
         # Sort value. If sort order is ascending, each enum value's sort value is itself. Otherwise,
@@ -94,10 +94,7 @@ def sort_clause(
             sort_tuple = zip(sorted_values, sorted_values)
         else:
             sort_tuple = zip(sorted_values, reversed(sorted_values))
-        sort_column = sqlalchemy.case(
-            {key: sort_value for (key, sort_value) in sort_tuple},
-            value=sort_column,
-        )
+        sort_column = sqlalchemy.case(dict(sort_tuple), value=sort_column)
     else:
         if not sort_ascending:
             sort_column = sort_column.desc()

--- a/jobbergate-api/jobbergate_api/tests/conftest.py
+++ b/jobbergate-api/jobbergate_api/tests/conftest.py
@@ -32,12 +32,20 @@ CHARSET = string.ascii_letters + string.digits + string.punctuation
 
 
 @pytest.fixture(autouse=True, scope="session")
-async def enforce_empty_database():
+async def database_engine():
+    """
+    Provide a fixture to get access to the database engine with a fixture.
+    """
+    engine = sqlalchemy.create_engine(build_db_url())
+    yield engine
+
+
+@pytest.fixture(autouse=True, scope="session")
+async def enforce_empty_database(database_engine):
     """
     Make sure our database is empty at the end of each test.
     """
-    engine = sqlalchemy.create_engine(build_db_url())
-    metadata.create_all(engine)
+    metadata.create_all(database_engine)
     yield
 
     await database.connect()
@@ -46,7 +54,7 @@ async def enforce_empty_database():
         assert count == 0
     await database.disconnect()
 
-    metadata.drop_all(engine)
+    metadata.drop_all(database_engine)
 
 
 @pytest.fixture(autouse=True)

--- a/jobbergate-api/jobbergate_api/tests/test_storage.py
+++ b/jobbergate-api/jobbergate_api/tests/test_storage.py
@@ -2,7 +2,13 @@
 Test the storage module.
 """
 
-from jobbergate_api.storage import build_db_url
+import enum
+
+import pytest
+from sqlalchemy import Table, Integer, Enum, Column
+
+from jobbergate_api.metadata import metadata
+from jobbergate_api.storage import build_db_url, sort_clause, database, render_sql
 
 
 def test_build_db_url__creates_database_url_from_parts(tweak_settings):
@@ -53,3 +59,70 @@ def test_build_db_url__uses_TEST_prefixed_database_settings_if_passed_the_force_
         assert build_db_url() == (
             "postgresql://built-test-user:built-test-pswd@built-test-host:9999/built-test-name"
         )
+
+@pytest.mark.asyncio
+async def test_sort_clause__auto_sort_enum_column(database_engine):
+
+    class DummyStatusEnum(str, enum.Enum):
+        CREATED = "CREATED"
+        SUBMITTED = "SUBMITTED"
+        COMPLETED = "COMPLETED"
+        FAILED = "FAILED"
+        UNKNOWN = "UNKNOWN"
+        REJECTED = "REJECTED"
+
+
+
+    dummy_table = Table(
+        'dummies',
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("status", Enum(DummyStatusEnum, sort_key_function=lambda v: str(v.value)), nullable=False),
+    )
+    dummy_sortables = [
+        dummy_table.c.id,
+        dummy_table.c.status
+    ]
+
+    # Note: do not worry about dropping the table. The pytest fixtures will clean it up for us
+    dummy_table.create(database_engine)
+    await database.execute_many(
+        query=dummy_table.insert(),
+        values=[
+            dict(id=44, status="COMPLETED"),
+            dict(id=45, status="FAILED"),
+            dict(id=46, status="REJECTED"),
+            dict(id=47, status="COMPLETED"),
+            dict(id=48, status="CREATED"),
+            dict(id=49, status="SUBMITTED"),
+            dict(id=50, status="REJECTED"),
+            dict(id=51, status="FAILED"),
+        ],
+    )
+    status_sort_clause = sort_clause("status", dummy_sortables, True)
+    query = dummy_table.select().order_by(status_sort_clause, "id")
+    results = await database.fetch_all(query)
+    assert [(d["id"], d["status"]) for d in results] == [
+        (44, "COMPLETED"),
+        (47, "COMPLETED"),
+        (48, "CREATED"),
+        (45, "FAILED"),
+        (51, "FAILED"),
+        (46, "REJECTED"),
+        (50, "REJECTED"),
+        (49, "SUBMITTED"),
+    ]
+
+    status_sort_clause = sort_clause("status", dummy_sortables, False)
+    query = dummy_table.select().order_by(status_sort_clause, "id")
+    results = await database.fetch_all(query)
+    assert [(d["id"], d["status"]) for d in results] == [
+        (49, "SUBMITTED"),
+        (46, "REJECTED"),
+        (50, "REJECTED"),
+        (45, "FAILED"),
+        (51, "FAILED"),
+        (48, "CREATED"),
+        (44, "COMPLETED"),
+        (47, "COMPLETED"),
+    ]

--- a/jobbergate-api/jobbergate_api/tests/test_storage.py
+++ b/jobbergate-api/jobbergate_api/tests/test_storage.py
@@ -5,10 +5,10 @@ Test the storage module.
 import enum
 
 import pytest
-from sqlalchemy import Table, Integer, Enum, Column
+from sqlalchemy import Column, Enum, Integer, Table
 
 from jobbergate_api.metadata import metadata
-from jobbergate_api.storage import build_db_url, sort_clause, database, render_sql
+from jobbergate_api.storage import build_db_url, database, sort_clause
 
 
 def test_build_db_url__creates_database_url_from_parts(tweak_settings):
@@ -60,8 +60,14 @@ def test_build_db_url__uses_TEST_prefixed_database_settings_if_passed_the_force_
             "postgresql://built-test-user:built-test-pswd@built-test-host:9999/built-test-name"
         )
 
+
 @pytest.mark.asyncio
 async def test_sort_clause__auto_sort_enum_column(database_engine):
+    """
+    Provide a test case for the ``sort_clause()`` function.
+
+    Test that the sort_clause() function will correctly sort enum columns.
+    """
 
     class DummyStatusEnum(str, enum.Enum):
         CREATED = "CREATED"
@@ -71,18 +77,13 @@ async def test_sort_clause__auto_sort_enum_column(database_engine):
         UNKNOWN = "UNKNOWN"
         REJECTED = "REJECTED"
 
-
-
     dummy_table = Table(
-        'dummies',
+        "dummies",
         metadata,
         Column("id", Integer, primary_key=True),
         Column("status", Enum(DummyStatusEnum, sort_key_function=lambda v: str(v.value)), nullable=False),
     )
-    dummy_sortables = [
-        dummy_table.c.id,
-        dummy_table.c.status
-    ]
+    dummy_sortables = [dummy_table.c.id, dummy_table.c.status]
 
     # Note: do not worry about dropping the table. The pytest fixtures will clean it up for us
     dummy_table.create(database_engine)


### PR DESCRIPTION
#### What
Fixed sort order for enum columns.

#### Why
Because it was sorting them by insert order (of the enum)

`Task`: https://app.clickup.com/t/18022949/ARMADA-811

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
