### PR TITLE
Modify cache dir and dotenv path

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -10,6 +10,7 @@ Unreleased
 - Added ``OIDC_USE_HTTPS`` setting to allow non-https OIDC hosts
 - Removed cluster validation from job-submission due to reliance on external cluster registry
 - Added a `show-files` subcommand to `job-scripts` to show job script files
+- Renamed cache dir and dotenv path in order to avoid conflicts when installed alongside legacy jobbergate
 
 3.2.5-alpha.0 -- 2022-09-15
 ---------------------------

--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -10,7 +10,7 @@ Unreleased
 - Added ``OIDC_USE_HTTPS`` setting to allow non-https OIDC hosts
 - Removed cluster validation from job-submission due to reliance on external cluster registry
 - Added a `show-files` subcommand to `job-scripts` to show job script files
-- Renamed cache dir and dotenv path in order to avoid conflicts when installed alongside legacy jobbergate
+- Modified cache dir and dotenv path in order to avoid conflicts when installed alongside legacy jobbergate
 
 3.2.5-alpha.0 -- 2022-09-15
 ---------------------------

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     Provide a ``pydantic`` settings model to hold configuration values loaded from the environment.
     """
 
-    JOBBERGATE_CACHE_DIR: Path = Field(Path.home() / ".local/share/jobbergate")
+    JOBBERGATE_CACHE_DIR: Path = Field(Path.home() / ".local/share/jobbergate3")
 
     ARMADA_API_BASE: AnyHttpUrl = Field("https://armada-k8s.staging.omnivector.solutions")
 

--- a/jobbergate-cli/jobbergate_cli/constants.py
+++ b/jobbergate-cli/jobbergate_cli/constants.py
@@ -25,7 +25,7 @@ JOBBERGATE_JOB_SUBMISSION_CONFIG = {
     "job_script_id": "",
 }
 
-JOBBERGATE_DEFAULT_DOTENV_PATH = Path("/etc/default/jobbergate-cli")
+JOBBERGATE_DEFAULT_DOTENV_PATH = Path("/etc/default/jobbergate3-cli")
 JOBBERGATE_APPLICATION_SUPPORTED_FILES = {".py", ".yaml", ".j2", ".jinja2"}
 JOBBERGATE_APPLICATION_MODULE_FILE_NAME = "jobbergate.py"
 JOBBERGATE_APPLICATION_CONFIG_FILE_NAME = "jobbergate.yaml"


### PR DESCRIPTION
#### What
Change the values for cache dir and dotenv path

#### Why
In order to avoid conflicts when installed alongside legacy jobbergate

`Task`: https://app.clickup.com/t/18022949/ARMADA-799

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
