### PR TITLE
lock the poetry version on GitHub actions

### DIFF
--- a/.github/workflows/publish-to-ecr.yaml
+++ b/.github/workflows/publish-to-ecr.yaml
@@ -32,6 +32,8 @@ jobs:
           python-version: 3.8
 
       - uses: Gr1N/setup-poetry@v7
+        with:
+          poetry-version: 1.1.14
 
       - id: poetry-package-version
         name: Get version of project from poetry

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.1.8
+          poetry-version: 1.1.14
 
       - name: Build docs
         working-directory: ./jobbergate-docs

--- a/.github/workflows/publish_on_tag.yaml
+++ b/.github/workflows/publish_on_tag.yaml
@@ -26,6 +26,8 @@ jobs:
           python-version: 3.8.10
   
       - uses: Gr1N/setup-poetry@v7
+        with:
+          poetry-version: 1.1.14
 
       - id: poetry-package-version
         name: Get project's version

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -32,7 +32,7 @@ jobs:
           architecture: 'x64'
       - uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.1.11
+          poetry-version: 1.1.14
       - name: "run quality control checks"
         working-directory: jobbergate-api
         env:
@@ -56,7 +56,7 @@ jobs:
           architecture: 'x64'
       - uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.1.11
+          poetry-version: 1.1.14
       - name: "run quality control checks"
         working-directory: jobbergate-cli
         env:


### PR DESCRIPTION
#### What
Lock the poetry version on GitHub actions

#### Why
To make sure we have consistent behavior on the actions.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
