### PR TITLE
ARMADA-835 Fix token refresh workflow in Jobbergate

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 Unreleased
 ----------
+- Fixed refresh token
 
 3.3.0 -- 2022-10-04
 -------------------

--- a/jobbergate-cli/jobbergate_cli/auth.py
+++ b/jobbergate-cli/jobbergate_cli/auth.py
@@ -203,7 +203,7 @@ def refresh_access_token(ctx: JobbergateContext, token_set: TokenSet):
 
     If refresh fails, notify the user that they need to log in again.
     """
-    url = f"https://{settings.OIDC_DOMAIN}/token"
+    url = f"https://{settings.OIDC_DOMAIN}/protocol/openid-connect/token"
     logger.debug(f"Requesting refreshed access token from {url}")
 
     JobbergateCliError.require_condition(
@@ -219,7 +219,7 @@ def refresh_access_token(ctx: JobbergateContext, token_set: TokenSet):
         make_request(
             # Can this even work? this client should be for the armada api...
             ctx.client,
-            "/token",
+            "/protocol/openid-connect/token",
             "POST",
             abort_message="The auth token could not be refreshed. Please try logging in again.",
             abort_subject="EXPIRED ACCESS TOKEN",

--- a/jobbergate-cli/tests/test_auth.py
+++ b/jobbergate-cli/tests/test_auth.py
@@ -365,7 +365,7 @@ def test_init_persona__refreshes_access_token_if_it_is_expired(make_token, tmp_p
         expires="2022-02-17 22:30:00",
     )
 
-    respx_mock.post(f"{LOGIN_DOMAIN}/token").mock(
+    respx_mock.post(f"{LOGIN_DOMAIN}/protocol/openid-connect/token").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json=dict(access_token=refreshed_access_token),
@@ -391,7 +391,8 @@ def test_init_persona__refreshes_access_token_if_it_is_expired(make_token, tmp_p
 def test_refresh_access_token__success(make_token, respx_mock, dummy_context):
     """
     Validate that the ``refreshed_access_token()`` function uses a refresh token to retrieve a new access
-    token from the ``oauth/token`` endpoint of the ``settings.OIDC_DOMAIN``.
+    token from the ``oauth/protocol/openid-connect/token``
+    endpoint of the ``settings.OIDC_DOMAIN``.
     """
     access_token = "expired-access-token"
     refresh_token = "dummy-refresh-token"
@@ -403,7 +404,7 @@ def test_refresh_access_token__success(make_token, respx_mock, dummy_context):
         expires="2022-02-17 22:30:00",
     )
 
-    respx_mock.post(f"{LOGIN_DOMAIN}/token").mock(
+    respx_mock.post(f"{LOGIN_DOMAIN}/protocol/openid-connect/token").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json=dict(access_token=refreshed_access_token),
@@ -417,13 +418,14 @@ def test_refresh_access_token__success(make_token, respx_mock, dummy_context):
 def test_refresh_access_token__raises_abort_on_non_200_response(respx_mock, dummy_context):
     """
     Validate that the ``refreshed_access_token()`` function raises an abort if the response from the
-    ``oauth/token`` endpoint of the ``settings.OIDC_DOMAIN`` is not a 200.
+    ``oauth//protocol/openid-connect/token`` endpoint of the
+    ``settings.OIDC_DOMAIN`` is not a 200.
     """
     access_token = "expired-access-token"
     refresh_token = "dummy-refresh-token"
     token_set = TokenSet(access_token=access_token, refresh_token=refresh_token)
 
-    respx_mock.post(f"{LOGIN_DOMAIN}/token").mock(
+    respx_mock.post(f"{LOGIN_DOMAIN}/protocol/openid-connect/token").mock(
         return_value=httpx.Response(
             httpx.codes.BAD_REQUEST,
             json=dict(error_description="BOOM!"),


### PR DESCRIPTION
#### What
Fix token refresh workflow in Jobbergate.

#### Why
Refreshing a token does not work in the current version of jobbergate-cli . Investigate and fix the issue.

`Task`: https://app.clickup.com/t/18022949/ARMADA-835

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
