### PR TITLE
Updated motorbike jobbergate example to use variable workdir

### DIFF
--- a/examples/motorbike-application/jobbergate.py
+++ b/examples/motorbike-application/jobbergate.py
@@ -1,5 +1,5 @@
 from jobbergate_cli.subapps.applications.application_base import JobbergateApplicationBase
-from jobbergate_cli.subapps.applications.questions import Text, Integer, Directory
+from jobbergate_cli.subapps.applications.questions import Text, Integer
 
 
 class JobbergateApplication(JobbergateApplicationBase):

--- a/examples/motorbike-application/jobbergate.py
+++ b/examples/motorbike-application/jobbergate.py
@@ -1,5 +1,5 @@
 from jobbergate_cli.subapps.applications.application_base import JobbergateApplicationBase
-from jobbergate_cli.subapps.applications.questions import Text, Integer
+from jobbergate_cli.subapps.applications.questions import Text, Integer, Directory
 
 
 class JobbergateApplication(JobbergateApplicationBase):
@@ -22,5 +22,10 @@ class JobbergateApplication(JobbergateApplicationBase):
             message="Choose number of tasks per node for job",
             default=6,
             minval=1,
+        ))
+        questions.append(Text(
+            "workdir",
+            message="Choose working directory (will hold results as well)",
+            default="/nfs",
         ))
         return questions

--- a/examples/motorbike-application/jobbergate.yaml
+++ b/examples/motorbike-application/jobbergate.yaml
@@ -5,3 +5,4 @@ application_config:
   partition: compute
   nodes: 2
   ntasks: 1
+  workdir: /nfs

--- a/examples/motorbike-application/templates/job-script-template.py.j2
+++ b/examples/motorbike-application/templates/job-script-template.py.j2
@@ -3,28 +3,28 @@
 #SBATCH --nodes={{ data.nodes }}
 #SBATCH --ntasks={{ data.ntasks }}
 #SBATCH -J motorbike
-#SBATCH --output=/nfs/R-%x.%j.out
-#SBATCH --error=/nfs/R-%x.%j.err
+#SBATCH --output={{ data.workdir }}/R-%x.%j.out
+#SBATCH --error={{ data.workdir }}/R-%x.%j.err
 #SBATCH -t 1:00:00
 
 # clone OpenFOAM-10 if it is not available yet
-OPENFOAM_DIR=/nfs/OpenFOAM-10
+OPENFOAM_DIR={{ data.workdir }}/OpenFOAM-10
 if [[ ! -d $OPENFOAM_DIR ]]
 then
     echo "Cloning OpenFOAM-10"
-    cd /nfs
+    cd {{ data.workdir }}
     git clone https://github.com/OpenFOAM/OpenFOAM-10.git
 else
     echo "Skipping clone process...we already have the OpenFOAM-10 source code"
 fi
 
 # create a working folder inside the shared directory
-WORK_DIR=/nfs/$SLURM_JOB_NAME-Job-$SLURM_JOB_ID
+WORK_DIR={{ data.workdir }}/$SLURM_JOB_NAME-Job-$SLURM_JOB_ID
 mkdir -p $WORK_DIR
 cd $WORK_DIR
 
 # path to the openfoam singularity image
-export SINGULARITY_IMAGE=/nfs/openfoam10.sif
+export SINGULARITY_IMAGE={{ data.workdir }}/openfoam10.sif
 
 # download the openfoam v10 singularity image if it is not available yet
 if [[ ! -f $SINGULARITY_IMAGE ]]

--- a/examples/simple-application/jobbergate.py
+++ b/examples/simple-application/jobbergate.py
@@ -8,9 +8,15 @@ class JobbergateApplication(JobbergateApplicationBase):
         if data is None:
             data=dict()
         data["nextworkflow"] = "subflow"
-        return [Text("foo", message="gimme the foo!"), Text("bar", message="gimme the bar!")]
+        return [
+            Text("foo", message="gimme the foo!"),
+            Text("bar", message="gimme the bar!"),
+        ]
 
     def subflow(self, data=None):
         if data is None:
             data=dict()
-        return [Text("baz", message="gimme the baz!", default="zab")]
+        return [
+            Text("baz", message="gimme the baz!", default="zab"),
+            Text("workdir", message="gimme the workdir!", default="/nfs"),
+        ]

--- a/examples/simple-application/jobbergate.yaml
+++ b/examples/simple-application/jobbergate.yaml
@@ -5,3 +5,4 @@ application_config:
   foo: FOO
   bar: BAR
   baz: BAZ
+  workdir: /nfs

--- a/examples/simple-application/templates/dummy-script.py.j2
+++ b/examples/simple-application/templates/dummy-script.py.j2
@@ -4,7 +4,7 @@
 #SBATCH -t 60
 
 print("Executing dummy job script")
-with open("/nfs/dummy-output.txt", mode="w") as dump_file:
+with open("{{ data['workdir'] }}/dummy-output.txt", mode="w") as dump_file:
     print("I am a very, very dumb job script", file=dump_file)
     print("foo={{ data['foo'] }}", file=dump_file)
     print("bar={{ data['bar'] }}", file=dump_file)

--- a/jobbergate-composed/docker-compose.yml
+++ b/jobbergate-composed/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - OIDC_CLIENT_ID=cli
       - OIDC_USE_HTTPS=false
       - JOBBERGATE_CACHE_DIR=/cache
+      - DEFAULT_CLUSTER_NAME=local-slurm
 
   # When the jobbegate-agent is completed, it will be included here and not rely on a
   # relative path outside of the jobbergate git repo


### PR DESCRIPTION
#### What
Made the job script in the motorbike example use a template var for workdir.

#### Why
It will allow the example to run in a different environment where there may not be a `/nfs` directory to work in.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
