### PR TITLE
Patch file upload with CRLF line endings

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 Unreleased
 ----------
+- Fixed issues with `CRLF` end of lines when uploading application files
 
 3.3.1 -- 2022-10-10
 -------------------

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
@@ -4,6 +4,7 @@ Provide tool functions for working with Application data.
 
 import contextlib
 import copy
+import io
 import pathlib
 from typing import Any, Dict, Optional, Tuple, cast
 
@@ -141,7 +142,7 @@ def get_upload_files(application_path: pathlib.Path):
         yield [
             (
                 "upload_files",
-                (path.name, stack.enter_context(open(path)), "text/plain"),
+                (path.name, stack.enter_context(io.open(path, mode="r", newline="")), "text/plain"),
             )
             for path in application_path.rglob("*")
             if path.is_file() and path.suffix in JOBBERGATE_APPLICATION_SUPPORTED_FILES


### PR DESCRIPTION
#### What
Patch file upload with CRLF line endings, resulting in the error:

```
/home/fschuch/jobbergate/jobbergate-cli/.venv/lib/python3.8/site-packages/h11/_writers.py:83 in
send_eom

   80 │
   81 │   def send_eom(self, headers, write):
   82 │   │   if self._length != 0:
❱  83 │   │   │   raise LocalProtocolError("Too little data for declared Content-Length")
   84 │   │   if headers:
   85 │   │   │   raise LocalProtocolError("Content-Length and trailers don't mix")
   86
```

The fix involves using `io.open` with the argument `newline=""`, which has proved to be more flexible than the standard `open` with different line endings.

#### Why
A bug was identified when trying to upload them.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
