### PR TITLE
Patch file manager

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Fixed a but at the file manager where the search for objects at s3 was not restricted to a single folder
 
 3.3.2-alpha.0 -- 2022-10-12
 ---------------------------

--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,7 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
-- Fixed a but at the file manager where the search for objects at s3 was not restricted to a single folder
+- Fixed a bug at the file manager where the search for objects at s3 was not restricted to a single folder
 
 3.3.2-alpha.0 -- 2022-10-12
 ---------------------------

--- a/jobbergate-api/jobbergate_api/s3_manager.py
+++ b/jobbergate-api/jobbergate_api/s3_manager.py
@@ -27,16 +27,16 @@ This constant can be shared between file managers.
 """
 
 
-def engine_factory(*, s3_client: BaseClient, bucket_name: str, work_directory: Path) -> EngineS3:
+def engine_factory(*, s3_client: BaseClient, bucket_name: str, prefix: str) -> EngineS3:
     """
     Build an engine to manipulate objects from an s3 bucket.
 
     :param BaseClient s3_client: S3 client from boto3
     :param str bucket_name: The name of the s3 bucket
-    :param Path work_directory: Work directory (referred as prefix at boto3 documentation)
+    :param str prefix: Prefix for object search at s3 (Work directory)
     :return EngineS3: And engine to manipulate files from s3
     """
-    return EngineS3(s3_client=s3_client, bucket_name=bucket_name, prefix=str(work_directory))
+    return EngineS3(s3_client=s3_client, bucket_name=bucket_name, prefix=prefix)
 
 
 @lru_cache(maxsize=128)
@@ -64,7 +64,7 @@ def file_manager_factory(
         engine=engine_factory(
             s3_client=s3_client,
             bucket_name=bucket_name,
-            work_directory=work_directory / str(id),
+            prefix=f"{work_directory}/{id}/",
         ),
         io_transformations=transformations,
     )

--- a/jobbergate-api/jobbergate_api/tests/conftest.py
+++ b/jobbergate-api/jobbergate_api/tests/conftest.py
@@ -8,7 +8,6 @@ import datetime
 import random
 import string
 import typing
-from pathlib import Path
 from textwrap import dedent
 from unittest.mock import patch
 
@@ -303,8 +302,8 @@ def mocked_file_manager_factory(tmp_path):
     It also clears the cache from file_manager_factory.
     """
 
-    def local_engine_factory(*, work_directory: Path, **kwargs):
-        return EngineLocal(base_path=tmp_path / work_directory)
+    def local_engine_factory(*, prefix: str, **kwargs):
+        return EngineLocal(base_path=tmp_path / prefix)
 
     file_manager_factory.cache_clear()
 

--- a/jobbergate-api/jobbergate_api/tests/test_s3_manager.py
+++ b/jobbergate-api/jobbergate_api/tests/test_s3_manager.py
@@ -2,8 +2,6 @@
 Test s3 manager.
 """
 
-from pathlib import Path
-
 import pytest
 from boto3 import client
 
@@ -30,7 +28,7 @@ class TestEngineFactory:
         return engine_factory(
             s3_client=client,
             bucket_name="test-bucket",
-            work_directory=Path("test-dir"),
+            prefix="test-dir",
         )
 
     def test_client(self, s3_engine, client):


### PR DESCRIPTION
#### What
Patch the file manager.

#### Why
A missing slash was causing us many troubles. For instance, when searching at s3 for objects with the prefix `applications/1`, `applications/10/jobbergate.py` was a match. The corrected way would be to search for `applications/1/`, with the trailing slash. Also, notice `pathlib.Path` always removes any trailing slash, so `prefix` was modified to be an `str`.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
