### PR TITLE
Made output_dir optional (as it is in the CLI)

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/applications/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/applications/schemas.py
@@ -101,7 +101,7 @@ class JobbergateConfig(BaseModel):
     supporting_files_output_name: Optional[Dict[str, List[str]]]
     template_files: Optional[List[str]]
     job_script_name: Optional[str]
-    output_directory: str = "."
+    output_directory: Optional[str] = "."
 
     @root_validator(pre=True)
     def compute_extra_settings(cls, values):


### PR DESCRIPTION
#### What
Made the `output_dir` parameter optional.

#### Why
It has a default and is optional for the CLI. Users expect it to be optional.


---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
