### PR TITLE
Patch the action to publish the documentation

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -43,3 +43,4 @@ jobs:
         run: |
           VERSION=`poetry version -s`
           aws s3 sync ./build s3://docs.omnivector.solutions/jobbergate/$VERSION
+          aws s3 sync ./build s3://docs.omnivector.solutions/jobbergate/latest


### PR DESCRIPTION
#### What
This PR applies a simple change in the github action that publishes the documentation. It simply adds a new path prefix for the latest docs, which is `/latest`. Now the docs can be accessed by two paths:

1. `https://docs.omnivector.solutions/jobbergate/latest/index.html`
   * It will access the latest published version
2. `https://docs.omnivector.solutions/jobbergate/<version>/index.html`
   * It will access the pinned version

#### Why

Make it easier for folks to access the docs

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
