### PR TITLE
ASP-2104 Fix report message on job-submission detailed view from the CLI

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to jobbergate-cli
 Unreleased
 ----------
 - Make the name optional when creating a new job script on the CLI
+- Fixed `report_message` not showing on the detailed view of a job submissions
 
 3.3.3 -- 2022-10-17
 -------------------

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -144,6 +144,7 @@ class JobSubmissionResponse(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     status: str
     created_at: Optional[datetime]
     updated_at: Optional[datetime]
+    report_message: Optional[str]
 
 
 class JobScriptCreateRequestData(pydantic.BaseModel):

--- a/jobbergate-cli/tests/subapps/conftest.py
+++ b/jobbergate-cli/tests/subapps/conftest.py
@@ -188,6 +188,18 @@ def dummy_job_submission_data(dummy_job_script_data):
             slurm_job_id=9999,
             status="CREATED",
         ),
+        dict(
+            id=4,
+            created_at="2022-11-17 11:17:00",
+            updated_at="2022-11-17 11:17:00",
+            job_submission_name="sub4",
+            job_submission_description="Job Submission 4",
+            job_submission_owner_email="felipe@omnivector.solutions",
+            job_script_id=99,
+            slurm_job_id=9999,
+            status="REJECTED",
+            report_message="Failed to submit job to slurm",
+        ),
     ]
 
 

--- a/jobbergate-cli/tests/subapps/job_submissions/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_tools.py
@@ -216,7 +216,7 @@ def test_fetch_job_submission_data__success__using_id(
     dummy_job_submission_data,
     dummy_domain,
 ):
-    job_submission_data = dummy_job_submission_data[0]
+    job_submission_data = dummy_job_submission_data[3]
     job_submission_id = job_submission_data["id"]
     fetch_route = respx_mock.get(f"{dummy_domain}/jobbergate/job-submissions/{job_submission_id}")
     fetch_route.mock(
@@ -229,3 +229,4 @@ def test_fetch_job_submission_data__success__using_id(
     result = fetch_job_submission_data(dummy_context, job_submission_id)
     assert fetch_route.called
     assert result == JobSubmissionResponse(**job_submission_data)
+    assert result.report_message == job_submission_data.get("report_message")


### PR DESCRIPTION
#### What
The `report_message` field should be shown always be shown, including on the list and detailed view, and with the `--full` options.

#### Why
When listing a single job_submission the "report_message" field does not display. It does not even run if you run Jobbergate with the "–full" option.

`Task`: https://jira.scania.com/browse/ASP-2104

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
