### PR TITLE
ASP-2102 The job_script.name field should be optional

### DIFF
--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -11,14 +11,8 @@ from jobbergate_cli.constants import SortOrder
 from jobbergate_cli.exceptions import Abort, handle_abort
 from jobbergate_cli.render import StyleMapper, render_json, render_list_results, render_single_result, terminal_message
 from jobbergate_cli.requests import make_request
-from jobbergate_cli.schemas import (
-    JobbergateContext,
-    JobScriptCreateRequestData,
-    JobScriptResponse,
-    ListResponseEnvelope,
-)
-from jobbergate_cli.subapps.applications.tools import execute_application, fetch_application_data, load_application_data
-from jobbergate_cli.subapps.job_scripts.tools import fetch_job_script_data, validate_parameter_file
+from jobbergate_cli.schemas import JobbergateContext, JobScriptResponse, ListResponseEnvelope
+from jobbergate_cli.subapps.job_scripts.tools import create_job_script, fetch_job_script_data
 from jobbergate_cli.subapps.job_submissions.app import HIDDEN_FIELDS as JOB_SUBMISSION_HIDDEN_FIELDS
 from jobbergate_cli.subapps.job_submissions.tools import create_job_submission
 from jobbergate_cli.text_tools import dedent
@@ -156,39 +150,17 @@ def create(
     """
     jg_ctx: JobbergateContext = ctx.obj
 
-    # Make static type checkers happy
-    assert jg_ctx.client is not None
-
-    app_data = fetch_application_data(jg_ctx, id=application_id, identifier=application_identifier)
-    (app_config, app_module) = load_application_data(app_data)
-
-    request_data = JobScriptCreateRequestData(
-        application_id=app_data.id,
-        job_script_name=name,
-        sbatch_params=sbatch_params,
-        param_dict=app_config,
-        job_script_description=description,
+    job_script_result = create_job_script(
+        jg_ctx,
+        name,
+        application_id,
+        application_identifier,
+        description,
+        sbatch_params,
+        param_file,
+        fast,
     )
 
-    supplied_params = validate_parameter_file(param_file) if param_file else dict()
-    execute_application(app_module, app_config, supplied_params, fast_mode=fast)
-
-    if app_config.jobbergate_config.job_script_name is not None:
-        request_data.job_script_name = app_config.jobbergate_config.job_script_name
-
-    job_script_result = cast(
-        JobScriptResponse,
-        make_request(
-            jg_ctx.client,
-            "/jobbergate/job-scripts",
-            "POST",
-            expected_status=201,
-            abort_message="Couldn't create job script",
-            support=True,
-            request_model=request_data,
-            response_model_cls=JobScriptResponse,
-        ),
-    )
     render_single_result(
         jg_ctx,
         job_script_result,

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -107,9 +107,14 @@ def get_one(
 @handle_abort
 def create(
     ctx: typer.Context,
-    name: str = typer.Option(
-        ...,
-        help="The name of the job script to create.",
+    name: Optional[str] = typer.Option(
+        None,
+        help=dedent(
+            """
+            The name of the job script to create.
+            If this is not supplied, the name will be derived from the base application.
+            """
+        ),
     ),
     application_id: Optional[int] = typer.Option(
         None,

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
@@ -97,7 +97,7 @@ def create_job_script(
 
     request_data = JobScriptCreateRequestData(
         application_id=app_data.id,
-        job_script_name=name,
+        job_script_name=name if name else app_data.application_name,
         sbatch_params=sbatch_params,
         param_dict=app_config,
         job_script_description=description,

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
@@ -4,11 +4,12 @@ Provide tool functions for working with Job Script data
 
 import json
 import pathlib
-from typing import Any, Dict, cast
+from typing import Any, Dict, List, Optional, cast
 
 from jobbergate_cli.exceptions import Abort
 from jobbergate_cli.requests import make_request
-from jobbergate_cli.schemas import JobbergateContext, JobScriptResponse
+from jobbergate_cli.schemas import JobbergateContext, JobScriptCreateRequestData, JobScriptResponse
+from jobbergate_cli.subapps.applications.tools import execute_application, fetch_application_data, load_application_data
 
 
 def validate_parameter_file(parameter_path: pathlib.Path) -> Dict[str, Any]:
@@ -66,3 +67,63 @@ def fetch_job_script_data(
             response_model_cls=JobScriptResponse,
         ),
     )
+
+
+def create_job_script(
+    jg_ctx: JobbergateContext,
+    name: Optional[str] = None,
+    application_id: Optional[int] = None,
+    application_identifier: Optional[str] = None,
+    description: Optional[str] = None,
+    sbatch_params: Optional[List[str]] = None,
+    param_file: Optional[pathlib.Path] = None,
+    fast: bool = False,
+) -> JobScriptResponse:
+    """
+    Create a new job script.
+
+    :param str name: Name of the new job script.
+    :param Optional[int] application_id: Id of the base application.
+    :param Optional[str] application_identifier: Identifier of the base application.
+    :param Optional[str] description: Description of the new job script.
+    :param Optional[List[str]] sbatch_params: List of sbatch parameters.
+    :param Optional[pathlib.Path] param_file: Path to a parameters file.
+    :param bool fast: Whether to use default answers (when available) instead of asking the user.
+    :param JobbergateContext jg_ctx: The Jobbergate context.
+    :return JobScriptResponse: The new job script.
+    """
+    app_data = fetch_application_data(jg_ctx, id=application_id, identifier=application_identifier)
+    (app_config, app_module) = load_application_data(app_data)
+
+    request_data = JobScriptCreateRequestData(
+        application_id=app_data.id,
+        job_script_name=name,
+        sbatch_params=sbatch_params,
+        param_dict=app_config,
+        job_script_description=description,
+    )
+
+    supplied_params = validate_parameter_file(param_file) if param_file else dict()
+    execute_application(app_module, app_config, supplied_params, fast_mode=fast)
+
+    if app_config.jobbergate_config.job_script_name is not None:
+        request_data.job_script_name = app_config.jobbergate_config.job_script_name
+
+    # Make static type checkers happy
+    assert jg_ctx.client is not None
+
+    job_script_result = cast(
+        JobScriptResponse,
+        make_request(
+            jg_ctx.client,
+            "/jobbergate/job-scripts",
+            "POST",
+            expected_status=201,
+            abort_message="Couldn't create job script",
+            support=True,
+            request_model=request_data,
+            response_model_cls=JobScriptResponse,
+        ),
+    )
+
+    return job_script_result

--- a/jobbergate-cli/tests/subapps/job_scripts/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_app.py
@@ -133,7 +133,7 @@ def test_create__non_fast_mode_and_job_submission(
     test_app = make_test_app("create", create)
     mocked_render = mocker.patch("jobbergate_cli.subapps.job_scripts.app.render_single_result")
     mocked_fetch_application_data = mocker.patch(
-        "jobbergate_cli.subapps.job_scripts.app.fetch_application_data",
+        "jobbergate_cli.subapps.job_scripts.tools.fetch_application_data",
         return_value=application_response,
     )
     mocked_create_job_submission = mocker.patch(
@@ -254,7 +254,7 @@ def test_create__with_fast_mode_and_no_job_submission(
     test_app = make_test_app("create", create)
     mocked_render = mocker.patch("jobbergate_cli.subapps.job_scripts.app.render_single_result")
     mocked_fetch_application_data = mocker.patch(
-        "jobbergate_cli.subapps.job_scripts.app.fetch_application_data",
+        "jobbergate_cli.subapps.job_scripts.tools.fetch_application_data",
         return_value=application_response,
     )
     result = cli_runner.invoke(


### PR DESCRIPTION
#### What
Make the job script name default to the name of the Application it was created from during job_script creation instead raising an error if this field is missing.

#### Why
When the user attempts to render an application into a job_script, the "name" field is required. It should be optional (as it was in the legacy CLI)

`Task`: https://jira.scania.com/browse/ASP-2102

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
