### PR TITLE
ASP-2105 Create a local copy of job scripts

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
 - Added support for `execution_parameters` in job submission at the CLI
 - Added new command to download application files to the current working directory
 - Added new command to download job script files to the current working directory
+- Added new option to create-job-submission to allow download job script files to current working directory
 
 3.3.4 -- 2022-12-05
 -------------------

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -12,7 +12,11 @@ from jobbergate_cli.exceptions import Abort, handle_abort
 from jobbergate_cli.render import StyleMapper, render_json, render_list_results, render_single_result, terminal_message
 from jobbergate_cli.requests import make_request
 from jobbergate_cli.schemas import JobbergateContext, JobScriptResponse, ListResponseEnvelope
-from jobbergate_cli.subapps.job_scripts.tools import create_job_script, fetch_job_script_data, save_job_script_files
+from jobbergate_cli.subapps.job_scripts.tools import (
+    create_job_script,
+    download_job_script_files,
+    fetch_job_script_data,
+)
 from jobbergate_cli.subapps.job_submissions.app import HIDDEN_FIELDS as JOB_SUBMISSION_HIDDEN_FIELDS
 from jobbergate_cli.subapps.job_submissions.tools import create_job_submission
 from jobbergate_cli.text_tools import dedent
@@ -330,17 +334,14 @@ def download_files(
     Download the files from a job script to the current working directory.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    result = fetch_job_script_data(jg_ctx, id)
-    saved_files = save_job_script_files(
-        job_script_data=result,
-        destination_path=pathlib.Path.cwd(),
-    )
+    downloaded_files = download_job_script_files(id, jg_ctx)
+
     terminal_message(
         dedent(
             """
             A total of {} job script files were successfully downloaded.
             """.format(
-                len(saved_files)
+                len(downloaded_files)
             )
         ),
         subject="Job script download succeeded",

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
@@ -136,7 +136,7 @@ def save_job_script_files(
     destination_path: pathlib.Path,
 ) -> List[pathlib.Path]:
     """
-    Safe the job script files from the API response to the output path.
+    Save the job script files from the API response to the output path.
     """
     logger.debug(f"Saving job script files to {destination_path.as_posix()}")
     saved_files: List[pathlib.Path] = []
@@ -149,3 +149,15 @@ def save_job_script_files(
 
     logger.debug(f"The following files were saved: {list(map(str, saved_files))}")
     return saved_files
+
+
+def download_job_script_files(id: int, jg_ctx: JobbergateContext) -> List[pathlib.Path]:
+    """
+    Download the job script files from the API and save them to the current working directory.
+    """
+    result = fetch_job_script_data(jg_ctx, id)
+    downloaded_files = save_job_script_files(
+        job_script_data=result,
+        destination_path=pathlib.Path.cwd(),
+    )
+    return downloaded_files

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -13,6 +13,7 @@ from jobbergate_cli.exceptions import handle_abort
 from jobbergate_cli.render import StyleMapper, render_list_results, render_single_result, terminal_message
 from jobbergate_cli.requests import make_request
 from jobbergate_cli.schemas import JobbergateContext, ListResponseEnvelope
+from jobbergate_cli.subapps.job_scripts.tools import download_job_script_files
 from jobbergate_cli.subapps.job_submissions.tools import create_job_submission, fetch_job_submission_data
 
 
@@ -73,6 +74,10 @@ def create(
         readable=True,
         resolve_path=True,
     ),
+    download: bool = typer.Option(
+        False,
+        help="Download the job script files to the current working directory",
+    ),
 ):
     """
     Create a new job submission.
@@ -91,6 +96,10 @@ def create(
         cluster_name=cluster_name,
         execution_parameters_file=execution_parameters,
     )
+
+    if download:
+        download_job_script_files(job_script_id, jg_ctx)
+
     render_single_result(
         jg_ctx,
         result,

--- a/jobbergate-cli/tests/subapps/job_submissions/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_app.py
@@ -25,8 +25,13 @@ def test_create(
     param_file_path.write_text(json.dumps(job_submission_data.execution_parameters))
 
     mocked_render = mocker.patch("jobbergate_cli.subapps.job_submissions.app.render_single_result")
-    patched_create_job_submission = mocker.patch("jobbergate_cli.subapps.job_submissions.app.create_job_submission")
+    patched_create_job_submission = mocker.patch(
+        "jobbergate_cli.subapps.job_submissions.app.create_job_submission",
+    )
     patched_create_job_submission.return_value = job_submission_data
+    mocked_download_job_script = mocker.patch(
+        "jobbergate_cli.subapps.job_submissions.app.download_job_script_files",
+    )
 
     test_app = make_test_app("create", create)
     result = cli_runner.invoke(
@@ -38,6 +43,7 @@ def test_create(
                        --description='{job_submission_description}'
                        --job-script-id={job_script_id}
                        --execution-parameters={param_file_path}
+                       --download
                 """
             )
         ),
@@ -50,6 +56,7 @@ def test_create(
         title="Created Job Submission",
         hidden_fields=HIDDEN_FIELDS,
     )
+    mocked_download_job_script.assert_called_once_with(job_script_id, dummy_context)
 
 
 def test_list_all__makes_request_and_renders_results(


### PR DESCRIPTION
#### What
An option is added to the `create-job-submission` command that downloads the rendered job_script to the CWD.

#### Why
As a user of the Jobbergate CLI, I would like the option to have a local copy of the job_script created in my current working directory when I submit a job through the CLI so that I can review the job_script that is being submitted to Slurm.

`Task`: https://jira.scania.com/browse/ASP-2105

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
