### PR TITLE
ASP-2107 Allow lookup of job_submissions and job_scripts by the source item

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,7 +6,9 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
-* Move SBATCH params to Job Script submission
+- Move SBATCH params to Job Script submission
+- Added field `from_application_id` to filter job scripts on the list endpoint
+- Added field `from_job_script_id` to filter job submissions on the list endpoint
 
 3.3.4 -- 2022-12-05
 -------------------

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -173,6 +173,10 @@ async def job_script_list(
     all: Optional[bool] = Query(False),
     search: Optional[str] = Query(None),
     sort_field: Optional[str] = Query(None),
+    from_application_id: Optional[int] = Query(
+        None,
+        description="Filter job-scripts by the application-id they were created from.",
+    ),
     sort_ascending: bool = Query(True),
     token_payload: TokenPayload = Depends(guard.lockdown(Permissions.JOB_SCRIPTS_VIEW)),
 ):
@@ -191,6 +195,8 @@ async def job_script_list(
     identity_claims = IdentityClaims.from_token_payload(token_payload)
     if not all:
         query = query.where(job_scripts_table.c.job_script_owner_email == identity_claims.email)
+    if from_application_id is not None:
+        query = query.where(job_scripts_table.c.application_id == from_application_id)
     if search is not None:
         query = query.where(search_clause(search, searchable_fields))
     if sort_field is not None:

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -168,6 +168,10 @@ async def job_submission_list(
     ),
     search: Optional[str] = Query(None),
     sort_field: Optional[str] = Query(None),
+    from_job_script_id: Optional[int] = Query(
+        None,
+        description="Filter job-submissions by the job-script-id they were created from.",
+    ),
     sort_ascending: bool = Query(True),
     token_payload: TokenPayload = Depends(guard.lockdown(Permissions.JOB_SUBMISSIONS_VIEW)),
 ):
@@ -186,6 +190,8 @@ async def job_submission_list(
     if not all:
         query = query.where(job_submissions_table.c.job_submission_owner_email == identity_claims.email)
 
+    if from_job_script_id is not None:
+        query = query.where(job_submissions_table.c.job_script_id == from_job_script_id)
     if slurm_job_ids is not None and slurm_job_ids != "":
         try:
             job_ids = [int(i) for i in slurm_job_ids.split(",")]

--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -10,6 +10,8 @@ Unreleased
 - Added new command to download application files to the current working directory
 - Added new command to download job script files to the current working directory
 - Added new option to create-job-submission to allow download job script files to current working directory
+- Added parameters `from_application_id` to filter job scripts on the list command
+- Added parameters `from_job_script_id` to filter job submissions on the list command
 
 3.3.4 -- 2022-12-05
 -------------------

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -48,6 +48,10 @@ def list_all(
     search: Optional[str] = typer.Option(None, help="Apply a search term to results"),
     sort_order: SortOrder = typer.Option(SortOrder.UNSORTED, help="Specify sort order"),
     sort_field: Optional[str] = typer.Option(None, help="The field by which results should be sorted"),
+    from_application_id: Optional[int] = typer.Option(
+        None,
+        help="Filter job-scripts by the application-id they were created from.",
+    ),
 ):
     """
     Show available job scripts
@@ -65,6 +69,8 @@ def list_all(
         params["sort_ascending"] = SortOrder is SortOrder.ASCENDING
     if sort_field is not None:
         params["sort_field"] = sort_field
+    if from_application_id is not None:
+        params["from_application_id"] = from_application_id
 
     envelope = cast(
         ListResponseEnvelope,

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -120,9 +120,13 @@ def list_all(
     search: Optional[str] = typer.Option(None, help="Apply a search term to results"),
     sort_order: SortOrder = typer.Option(SortOrder.UNSORTED, help="Specify sort order"),
     sort_field: Optional[str] = typer.Option(None, help="The field by which results should be sorted"),
+    from_job_script_id: Optional[int] = typer.Option(
+        None,
+        help="Filter job-submissions by the job-script-id they were created from.",
+    ),
 ):
     """
-    Show available job scripts
+    Show available job submissions.
     """
     jg_ctx: JobbergateContext = ctx.obj
 
@@ -137,6 +141,8 @@ def list_all(
         params["sort_ascending"] = SortOrder is SortOrder.ASCENDING
     if sort_field is not None:
         params["sort_field"] = sort_field
+    if from_job_script_id is not None:
+        params["from_job_script_id"] = from_job_script_id
 
     envelope = cast(
         ListResponseEnvelope,


### PR DESCRIPTION
#### What
Allow lookup of job_submissions by the job-script they were created from and job-scripts by the application they were created from.

#### Why
As a Jobbergate CLI user, I would like to be able to look up a job_script by the application it was created from so that I can more quickly find a job_script from its source item

As a Jobbergate CLI user, I would like to be able to look up a job_submission by the job_script it was created from so that I can more quickly find a job_submission from its source item

`Task`: https://jira.scania.com/browse/ASP-2107

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
