### PR TITLE
ASP-2568 Ignore the leading "templates/" path in the supporting files

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,8 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Fix a compatibility issue on JobbergateConfig by removing the leading "templates/" on the path for template files
+
 
 3.4.0 -- 2023-01-03
 -------------------

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/job_script_files.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/job_script_files.py
@@ -243,9 +243,6 @@ class JobScriptFiles(BaseModel):
             app_config.jobbergate_config.default_template,
         )
 
-        if default_template_name.startswith("templates/"):
-            (_, default_template_name) = default_template_name.split("/", maxsplit=1)
-
         JobScriptCreationError.require_condition(
             default_template_name in application_files.templates,
             "Selected template {selected} not found in available templates: {templates}".format(
@@ -307,7 +304,7 @@ class JobScriptFiles(BaseModel):
         return jobscript_files
 
     @classmethod
-    def file_manager_factory(self, job_script_id: int) -> FileManager:
+    def file_manager_factory(cls, job_script_id: int) -> FileManager:
         """
         Build an application file manager.
         """

--- a/jobbergate-api/jobbergate_api/tests/apps/applications/test_schemas.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/applications/test_schemas.py
@@ -105,6 +105,40 @@ class TestJobbergateConfig:
 
         assert config.supporting_files_output_name == dict(foo=["bar"], baz=["qux"])
 
+    def test_remove_leading_template_on_path__default_template(self):
+        """
+        Test that the leading "templates/" is removed from the field default_template.
+        """
+        config = JobbergateConfig(default_template="templates/test_job_script.sh")
+
+        assert config.default_template == "test_job_script.sh"
+
+    def test_remove_leading_template_on_path__supporting_files_output_name(self):
+        """
+        Test that the leading "templates/" is removed from each key on the dict supporting_files_output_name.
+        """
+        config = JobbergateConfig(
+            supporting_files_output_name={"templates/test_job_script.sh": ["string"]},
+        )
+
+        assert config.supporting_files_output_name == {"test_job_script.sh": ["string"]}
+
+    def test_remove_leading_template_on_path__supporting_files(self):
+        """
+        Test that the leading "templates/" is removed from each entry on the list supporting_files.
+        """
+        config = JobbergateConfig(supporting_files=["templates/test_job_script.sh"])
+
+        assert config.supporting_files == ["test_job_script.sh"]
+
+    def test_remove_leading_template_on_path__template_files(self):
+        """
+        Test that the leading "templates/" is removed from each entry on the list template_files.
+        """
+        config = JobbergateConfig(template_files=["templates/test_job_script.sh"])
+
+        assert config.template_files == ["test_job_script.sh"]
+
 
 def test_application_config(reference_application_config, dummy_application_config):
     """

--- a/jobbergate-api/jobbergate_api/tests/apps/job_scripts/test_job_script_files.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/job_scripts/test_job_script_files.py
@@ -290,9 +290,45 @@ class TestJobScriptFiles:
     ):
         """
         Test that JobScriptFiles can be obtained when rendering ApplicationFiles.
+
+        In order to provide support to legacy jobbergate applications, we need to ignore the leading
+        "templates/" in path for the default_template.
         """
         mangled_param_dict = param_dict.copy()
         mangled_param_dict["jobbergate_config"]["default_template"] = "templates/test_job_script.sh"
+
+        desired_job_script_files = JobScriptFiles(
+            main_file_path="test_job_script.sh",
+            files={
+                "test_job_script.sh": job_script_data_as_string,
+                "support_file_b.py": job_script_data_as_string,
+            },
+        )
+
+        actual_job_script_files = JobScriptFiles.render_from_application(
+            dummy_application_files,
+            mangled_param_dict,
+        )
+
+        assert actual_job_script_files == desired_job_script_files
+
+    def test_render_from_application__ignores_template_path_prefix_in_supporting_files(
+        self,
+        param_dict,
+        job_script_data_as_string,
+        dummy_application_files,
+    ):
+        """
+        Test that JobScriptFiles can be obtained when rendering ApplicationFiles.
+
+        In order to provide support to legacy jobbergate applications, we need to ignore the leading
+        "templates/" in path for each of the supporting_files.
+        """
+        mangled_param_dict = param_dict.copy()
+        mangled_param_dict["jobbergate_config"]["supporting_files"] = ["templates/test_job_script.sh"]
+        mangled_param_dict["jobbergate_config"]["supporting_files_output_name"] = {
+            "templates/test_job_script.sh": ["support_file_b.py"]
+        }
 
         desired_job_script_files = JobScriptFiles(
             main_file_path="test_job_script.sh",


### PR DESCRIPTION
#### What
Jobbergate-API should ignore the leading ./templates/ from the file path when it is detected.

#### Why
Jobbergate v3 assumes that all templates files are on the directory `./templates/`, in this way, legacy jobbergate applications get an error when referring to them using this prefix on the file path.

`Task`: https://jira.scania.com/browse/ASP-2568

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
