### PR TITLE
ASP-2569 Enhancement: Capture rejection message from Slurm

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -408,9 +408,9 @@ async def job_submission_agent_update(
         .returning(job_submissions_table)
     )
     logger.trace(f"update_query = {render_sql(update_query)}")
-    result = await database.fetch_one(update_query)
+    job_submission_data = await database.fetch_one(update_query)
 
-    if result is None:
+    if job_submission_data is None:
         message = (
             f"JobSubmission with id={job_submission_id} "
             f"and client_id={identity_claims.client_id} not found."
@@ -422,9 +422,11 @@ async def job_submission_agent_update(
         )
 
     if report_message and new_status == JobSubmissionStatus.REJECTED:
-        notify_submission_rejected(job_submission_id, report_message, result["job_submission_owner_email"])
+        notify_submission_rejected(
+            job_submission_id, report_message, job_submission_data["job_submission_owner_email"]
+        )
 
-    return result
+    return JobSubmissionResponse(**job_submission_data)  # type: ignore
 
 
 @router.get(

--- a/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
@@ -1832,6 +1832,96 @@ async def test_job_submissions_agent_update__success(
 
 
 @pytest.mark.asyncio
+async def test_job_submissions_agent_update__job_rejected(
+    fill_application_data,
+    fill_job_script_data,
+    fill_all_job_submission_data,
+    client,
+    inject_security_header,
+):
+    """
+    Test PUT /job-submissions/{job_submission_id} correctly updates a job_submission status to rejected.
+
+    This test proves that a job_submission is successfully updated via a PUT request to the
+    /job-submissions/{job_submission_id} endpoint. We show this by asserting that the job_submission is
+    updated in the database after the post request is made, the correct status code (200) is returned.
+    We also show that the ``status`` column is set to the new status value.
+    """
+    inserted_application_id = await database.execute(
+        query=applications_table.insert(),
+        values=fill_application_data(),
+    )
+    inserted_job_script_id = await database.execute(
+        query=job_scripts_table.insert(),
+        values=fill_job_script_data(application_id=inserted_application_id),
+    )
+    await database.execute_many(
+        query=job_submissions_table.insert(),
+        values=fill_all_job_submission_data(
+            dict(
+                job_script_id=inserted_job_script_id,
+                job_submission_name="sub1",
+                status=JobSubmissionStatus.CREATED,
+                client_id="dummy-client",
+                slurm_job_id=None,
+                execution_parameters={"name": "job-submission-name", "comment": "I am a comment"},
+            ),
+            dict(
+                job_script_id=inserted_job_script_id,
+                job_submission_name="sub2",
+                status=JobSubmissionStatus.COMPLETED,
+                client_id="dummy-client",
+                slurm_job_id=None,
+            ),
+            dict(
+                job_script_id=inserted_job_script_id,
+                job_submission_name="sub3",
+                status=JobSubmissionStatus.CREATED,
+                client_id="silly-client",
+                slurm_job_id=None,
+            ),
+            dict(
+                job_script_id=inserted_job_script_id,
+                job_submission_name="sub4",
+                status=JobSubmissionStatus.CREATED,
+                client_id="dummy-client",
+                slurm_job_id=None,
+            ),
+        ),
+    )
+
+    count = await database.fetch_all("SELECT COUNT(*) FROM job_submissions")
+    assert count[0][0] == 4
+
+    target_job_submission = await database.fetch_one(
+        query=job_submissions_table.select().where(job_submissions_table.c.job_submission_name == "sub1")
+    )
+    assert target_job_submission is not None
+    job_submission_id = target_job_submission["id"]
+
+    inject_security_header(
+        "who@cares.com",
+        Permissions.JOB_SUBMISSIONS_EDIT,
+        client_id="dummy-client",
+    )
+    response = await client.put(
+        f"/jobbergate/job-submissions/agent/{job_submission_id}",
+        json=dict(
+            new_status=JobSubmissionStatus.REJECTED.value,
+            report_message="Job rejected by the system due to test-test",
+        ),
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    assert data["id"] == job_submission_id
+    assert data["status"] == JobSubmissionStatus.REJECTED
+    assert data["slurm_job_id"] is None
+    assert data["execution_directory"] is None
+    assert data["report_message"] == "Job rejected by the system due to test-test"
+
+
+@pytest.mark.asyncio
 async def test_job_submissions_agent_update__returns_400_if_token_does_not_carry_client_id(
     client,
     inject_security_header,

--- a/jobbergate-api/jobbergate_api/tests/test_email_notification.py
+++ b/jobbergate-api/jobbergate_api/tests/test_email_notification.py
@@ -8,7 +8,12 @@ from fastapi import HTTPException
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
 
-from jobbergate_api.email_notification import EmailManager, EmailNotificationError, notify_submission_rejected
+from jobbergate_api.email_notification import (
+    EmailManager,
+    EmailNotificationError,
+    email_manager,
+    notify_submission_rejected,
+)
 
 
 class TestEmailManager:
@@ -113,3 +118,19 @@ def test_notify_submission_rejected():
             to_emails=["support@pytesting.com", "someone@pytesting.com"],
         )
     mocked.assert_called_once()
+
+
+def test_notify_submission_rejected__from_email_unset():
+    """
+    Test that emails are not sent when the attribute `from_email` is undefined.
+
+    Also make sure this should not raise any exception.
+    """
+    with mock.patch.object(target=email_manager, attribute="from_email", new=None):
+        with mock.patch.object(target=email_manager.email_client, attribute="send") as mocked:
+            notify_submission_rejected(
+                job_submission_id=0,
+                report_message="something went wrong!",
+                to_emails=["support@pytesting.com", "someone@pytesting.com"],
+            )
+        mocked.assert_not_called()


### PR DESCRIPTION
#### What
Improve logs and tests in colaboration with https://github.com/omnivector-solutions/cluster-agent/pull/64.

#### Why
As a jobbergate user and maintainer, I would like to access the error message provided by Slurm when a job submission is rejected. To do so, jobbergate should use the database column report_message to store this information, and in this way, speed up troubleshooting.

`Task`: https://jira.scania.com/browse/ASP-2569

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
