### PR TITLE
Patch response on job-submission routes

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Fixed put endpoints on job-submission to return the correct data
 
 3.4.1 -- 2023-01-16
 -------------------

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -286,7 +286,7 @@ async def job_submission_update(job_submission_id: int, job_submission: JobSubmi
                 detail=message,
             )
 
-    return job_submission_data
+    return JobSubmissionResponse(**job_submission_data)  # type: ignore
 
 
 # The "agent" routes are used for agents to fetch pending job submissions and update their statuses
@@ -408,9 +408,9 @@ async def job_submission_agent_update(
         .returning(job_submissions_table)
     )
     logger.trace(f"update_query = {render_sql(update_query)}")
-    result = await database.fetch_one(update_query)
+    job_submission_data = await database.fetch_one(update_query)
 
-    if result is None:
+    if job_submission_data is None:
         message = (
             f"JobSubmission with id={job_submission_id} "
             f"and client_id={identity_claims.client_id} not found."
@@ -422,9 +422,11 @@ async def job_submission_agent_update(
         )
 
     if report_message and new_status == JobSubmissionStatus.REJECTED:
-        notify_submission_rejected(job_submission_id, report_message, result["job_submission_owner_email"])
+        notify_submission_rejected(
+            job_submission_id, report_message, job_submission_data["job_submission_owner_email"]
+        )
 
-    return result
+    return JobSubmissionResponse(**job_submission_data)  # type: ignore
 
 
 @router.get(

--- a/jobbergate-api/jobbergate_api/tests/apps/conftest.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/conftest.py
@@ -92,6 +92,7 @@ def job_submission_data():
         "job_submission_owner_email": "owner1@org.com",
         "client_id": "dummy-client-id",
         "status": JobSubmissionStatus.CREATED,
+        "execution_parameters": {"name": "job-submission-name", "comment": "I am a comment"},
     }
 
 

--- a/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
@@ -56,7 +56,6 @@ async def test_create_job_submission__with_client_id_in_token(
         job_script_id=inserted_job_script_id,
         job_submission_name="sub1",
         job_submission_owner_email="owner1@org.com",
-        execution_parameters={"name": "job-submission-name", "comment": "I am a comment"},
     )
 
     # Removed defaults to make sure these are correctly set by other mechanisms
@@ -148,6 +147,9 @@ async def test_create_job_submission__without_execution_parameters(
         job_submission_name="sub1",
         job_submission_owner_email="owner1@org.com",
     )
+
+    # This test aims to prove that the execution_parameters are optional
+    create_data.pop("execution_parameters", None)
 
     # Removed defaults to make sure these are correctly set by other mechanisms
     create_data.pop("status", None)
@@ -319,7 +321,6 @@ async def test_create_job_submission__with_execution_directory(
         job_submission_name="sub1",
         job_submission_owner_email="owner1@org.com",
         execution_directory="/some/fake/path",
-        execution_parameters={"name": "job-submission-name", "comment": "I am a comment"},
     )
 
     # Removed defaults to make sure these are correctly set by other mechanisms
@@ -503,10 +504,6 @@ async def test_get_job_submission_by_id(
             job_script_id=inserted_job_script_id,
             job_submission_name="sub1",
             job_submission_owner_email="owner1@org.com",
-            execution_parameters={
-                "name": "job-submission-name",
-                "comment": "I am a comment",
-            },
         ),
     )
 


### PR DESCRIPTION
#### What
Patch the response on job-submission routes, including:
* `PUT` on `/job-submissions/agent/{job_submission_id}`
* `PUT` on `/job-submissions/{job_submission_id}`

#### Why

This was resulting in a `422 Unprocessable Entity - HTTP` because aparently FastAPI can not parse the JSONB column `execution_parameters` to the `response_model=JobSubmissionResponse` automatically.

Notice there was no error on the update usability, it was in fact happening, but the error on the response was confusing on cluster-agent and the user interface.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
