### PR TITLE
ASP-2622 Handle special characters in the Jobbergate SBATCH parser

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to jobbergate-api
 Unreleased
 ----------
 
+- Patched the sbatch param parser to support special characters
+
 3.4.2 -- 2023-01-25
 -------------------
 - Fixed put endpoints on job-submission to return the correct data

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/properties_parser.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/properties_parser.py
@@ -4,6 +4,7 @@ Parser for Slurm REST API parameters from SBATCH parameters at the job script fi
 from argparse import ArgumentParser
 from dataclasses import dataclass, field
 from itertools import chain
+from shlex import split
 from typing import Any, Dict, List, Union
 
 from bidict import bidict
@@ -33,15 +34,6 @@ def _clean_line(line: str) -> str:
     return line.lstrip(_IDENTIFICATION_FLAG).split(_INLINE_COMMENT_MARK)[0].strip()
 
 
-def _split_line(line: str) -> List[str]:
-    """
-    Split the provided line at the equal and with spaces characters.
-
-    This procedure is important because it is the way argparse expects to receive the parameters.
-    """
-    return line.replace("=", " ").split()
-
-
 def _clean_jobscript(jobscript: str) -> List[str]:
     """
     Transform a job script string.
@@ -54,7 +46,7 @@ def _clean_jobscript(jobscript: str) -> List[str]:
     """
     jobscript_filtered = filter(_flagged_line, jobscript.splitlines())
     jobscript_cleaned = map(_clean_line, jobscript_filtered)
-    jobscript_splitted = map(_split_line, jobscript_cleaned)
+    jobscript_splitted = map(split, jobscript_cleaned)
     return list(chain.from_iterable(jobscript_splitted))
 
 


### PR DESCRIPTION
#### What
The SBATCH parser does not support any value that includes white spaces or the equal character `=`.

#### Why
As a nextgen Jobbergate user, I need the SBATCH parser in the API to handle special characters correctly so that it can handle all the different SBATCH parameters that are currently being used in the legacy use-case.

Investigating the SBATCH parameters, two parameters were identified that are supposed to use the special characters (--acctg-freq  and --comment ), for instance:

```python
#SBATCH --acctg-freq=task=60,energy=30,network=30,filesystem=60
#SBATCH --comment="Hi, I am a comment"
```

`Task`: https://jira.scania.com/browse/ASP-2622

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
