### PR TITLE
Add Dockerfile to Jobbergate docs

### DIFF
--- a/jobbergate-docs/Dockerfile
+++ b/jobbergate-docs/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.8-slim-buster AS builder
+
+WORKDIR /app
+
+RUN apt update && apt install -y curl libpq-dev gcc make
+
+RUN curl -sSL  https://install.python-poetry.org | \
+    POETRY_HOME=/opt/poetry POETRY_VERSION=1.1.13 python && \
+    cd /usr/local/bin && \
+    ln -s /opt/poetry/bin/poetry && \
+    poetry config virtualenvs.create false
+
+ADD jobbergate-docs /app/jobbergate-docs
+ADD jobbergate-core /app/jobbergate-core
+
+WORKDIR /app/jobbergate-docs
+
+RUN make docs
+
+FROM python:3.8-slim-buster AS final
+
+COPY --from=builder /app/jobbergate-docs/build /app/build
+
+CMD ["sh", "-c", "python -m http.server --bind 0.0.0.0 --directory /app/build 8887"]

--- a/jobbergate-docs/Dockerfile
+++ b/jobbergate-docs/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8-slim-buster AS builder
 
 WORKDIR /app
 
-RUN apt update && apt install -y curl libpq-dev gcc make
+RUN apt update && apt install -y curl make
 
 RUN curl -sSL  https://install.python-poetry.org | \
     POETRY_HOME=/opt/poetry POETRY_VERSION=1.1.13 python && \

--- a/jobbergate-docs/README.rst
+++ b/jobbergate-docs/README.rst
@@ -14,9 +14,16 @@ This repository contains the source for the Jobbergate Documentation page.
 It is built using [sphinx](https://www.sphinx-doc.org/en/master/) to render the source into
 a static website.
 
+Build and instanciate the Docs server using Docker
+==================================================
 
-Build the Docs
-==============
+To build the documentation site and deploy the server in a determined PORT, run the following command from `jobbergate` root directory::
+
+    $ docker build -t jobbergate-docs -f jobbergate-docs/Dockerfile .
+    $ docker run -p <PORT>:8887 jobbergate-docs
+
+Build the documentation static site
+===================================
 
 To build the documentation static site, run the following command::
 


### PR DESCRIPTION
#### What
Add Dockerfile to Jobbergate docs

#### Why

In order to facilitate the use of Jobbergate and following the standards already adopted in other sub-projects, it is interesting that we add a documentation service to Jobbergate, which is already distributed using docker.

Closes #242 