### PR TITLE
Include parent entity name in payloads

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -116,7 +116,8 @@ async def job_script_create(
     logger.debug(f"Job-script created: {dict(job_script_data)}")
 
     response = JobScriptResponse(
-        **{**job_script_data, "application_name": application.application_name},
+        **job_script_data,
+        application_name=application.application_name,
         job_script_files=jobscript_files,
     )
     return response

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/schemas.py
@@ -104,6 +104,7 @@ class JobScriptPartialResponse(BaseModel):
     job_script_description: Optional[str] = None
     job_script_owner_email: str
     application_id: int
+    application_name: Optional[str] = None
 
     class Config:
         orm_mode = True

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -116,7 +116,7 @@ async def job_submission_create(
     logger.debug(f"Job-submission created: {job_submission_data=}")
 
     return JobSubmissionResponse(
-        **{**job_submission_data, "job_script_name": raw_job_script.get("job_script_name")}  # type: ignore
+        **job_submission_data, job_script_name=raw_job_script.get("job_script_name")  # type: ignore
     )
 
 

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from armasec import TokenPayload
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from loguru import logger
-from sqlalchemy import select
+from sqlalchemy import join, select
 
 from jobbergate_api.apps.applications.models import applications_table
 from jobbergate_api.apps.job_scripts.job_script_files import JobScriptFiles
@@ -115,7 +115,9 @@ async def job_submission_create(
 
     logger.debug(f"Job-submission created: {job_submission_data=}")
 
-    return JobSubmissionResponse(**job_submission_data)  # type: ignore
+    return JobSubmissionResponse(
+        **{**job_submission_data, "job_script_name": raw_job_script.get("job_script_name")}  # type: ignore
+    )
 
 
 @router.get(
@@ -130,7 +132,17 @@ async def job_submission_get(job_submission_id: int = Query(...)):
     """
     logger.debug(f"Getting {job_submission_id=}")
 
-    query = job_submissions_table.select().where(job_submissions_table.c.id == job_submission_id)
+    query = (
+        select([job_submissions_table, job_scripts_table.c.job_script_name])
+        .select_from(
+            join(
+                job_submissions_table,
+                job_scripts_table,
+                job_submissions_table.c.job_script_id == job_scripts_table.c.id,
+            )
+        )
+        .where(job_submissions_table.c.id == job_submission_id)
+    )
     logger.trace(f"query = {render_sql(query)}")
     job_submission_data = await database.fetch_one(query)
 
@@ -181,7 +193,13 @@ async def job_submission_list(
     logger.debug("Fetching job submissions")
     identity_claims = IdentityClaims.from_token_payload(token_payload)
     logger.debug(f"Extracted identity claims from token: {identity_claims}")
-    query = job_submissions_table.select()
+    query = select([job_submissions_table, job_scripts_table.c.job_script_name]).select_from(
+        join(
+            job_submissions_table,
+            job_scripts_table,
+            job_submissions_table.c.job_script_id == job_scripts_table.c.id,
+        )
+    )
 
     logger.debug("Building query")
     if submit_status:
@@ -205,6 +223,8 @@ async def job_submission_list(
         query = query.where(search_clause(search, searchable_fields))
     if sort_field is not None:
         query = query.order_by(sort_clause(sort_field, sortable_fields, sort_ascending))
+    else:
+        query = query.order_by(job_submissions_table.c.id.asc())
 
     logger.trace(f"Query built as: {render_sql(query)}")
 

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -323,6 +323,7 @@ class JobSubmissionResponse(BaseModel):
     status: JobSubmissionStatus
     report_message: Optional[str]
     execution_parameters: Optional[JobProperties]
+    job_script_name: Optional[str] = None
 
     class Config:
         orm_mode = True

--- a/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_routers.py
@@ -26,6 +26,7 @@ async def test_create_job_submission__with_client_id_in_token(
     fill_application_data,
     fill_job_script_data,
     fill_job_submission_data,
+    job_script_data,
     client,
     inject_security_header,
     time_frame,
@@ -88,7 +89,9 @@ async def test_create_job_submission__with_client_id_in_token(
         query=job_submissions_table.select().where(job_submissions_table.c.id == id_rows[0][0])
     )
     assert job_submission_raw_data is not None
-    assert job_submission == JobSubmissionResponse(**job_submission_raw_data)  # type: ignore
+    assert job_submission == JobSubmissionResponse(
+        **{**job_submission_raw_data, **job_script_data}
+    )  # type: ignore
 
     # Check that each field is correctly set
     assert job_submission.id == job_submission_raw_data.get("id")
@@ -112,6 +115,7 @@ async def test_create_job_submission__without_execution_parameters(
     fill_application_data,
     fill_job_script_data,
     fill_job_submission_data,
+    job_script_data,
     client,
     inject_security_header,
     time_frame,
@@ -178,7 +182,9 @@ async def test_create_job_submission__without_execution_parameters(
         query=job_submissions_table.select().where(job_submissions_table.c.id == id_rows[0][0])
     )
     assert job_submission_raw_data is not None
-    assert job_submission == JobSubmissionResponse(**job_submission_raw_data)  # type: ignore
+    assert job_submission == JobSubmissionResponse(
+        **{**job_submission_raw_data, **job_script_data}
+    )  # type: ignore
 
     # Check that each field is correctly set
     assert job_submission.id == job_submission_raw_data.get("id")
@@ -204,6 +210,7 @@ async def test_create_job_submission__with_client_id_in_request_body(
     fill_application_data,
     fill_job_script_data,
     fill_job_submission_data,
+    job_script_data,
     client,
     inject_security_header,
     time_frame,
@@ -267,7 +274,9 @@ async def test_create_job_submission__with_client_id_in_request_body(
         query=job_submissions_table.select().where(job_submissions_table.c.id == id_rows[0][0])
     )
     assert job_submission_raw_data is not None
-    assert job_submission == JobSubmissionResponse(**job_submission_raw_data)  # type: ignore
+    assert job_submission == JobSubmissionResponse(
+        **{**job_submission_raw_data, **job_script_data}
+    )  # type: ignore
 
     # Check that each field is correctly set
     assert job_submission.id == job_submission_raw_data.get("id")
@@ -290,6 +299,7 @@ async def test_create_job_submission__with_execution_directory(
     fill_application_data,
     fill_job_script_data,
     fill_job_submission_data,
+    job_script_data,
     client,
     inject_security_header,
     time_frame,
@@ -353,7 +363,9 @@ async def test_create_job_submission__with_execution_directory(
         query=job_submissions_table.select().where(job_submissions_table.c.id == id_rows[0][0])
     )
     assert job_submission_raw_data is not None
-    assert job_submission == JobSubmissionResponse(**job_submission_raw_data)  # type: ignore
+    assert job_submission == JobSubmissionResponse(
+        **{**job_submission_raw_data, **job_script_data}
+    )  # type: ignore
 
     assert job_submission.id == job_submission_raw_data.get("id")
     assert job_submission.job_submission_name == "sub1"


### PR DESCRIPTION
#### What
* GET /job-scripts returns the application name for each entity returned
* GET /job-scripts/<id> returns the application name of the job script whose id is <id>
* GET/job-submissions returns the job script id for each entity returned
* GET/job-submissions/<id> returns the job script id of the job submission whose id is <id>

#### Why
Enable faster querying against the Jobbergate API

`Task`: https://app.clickup.com/t/18022949/PFT-1086 (private task)

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
