### PR TITLE
PFT-1022 Changed permissions of cached tokens to user read/write only…

### DIFF
--- a/jobbergate-cli/jobbergate_cli/auth.py
+++ b/jobbergate-cli/jobbergate_cli/auth.py
@@ -131,10 +131,12 @@ def save_tokens_to_cache(token_set: TokenSet):
 
     logger.debug(f"Caching access token at {settings.JOBBERGATE_ACCESS_TOKEN_PATH}")
     settings.JOBBERGATE_ACCESS_TOKEN_PATH.write_text(token_set.access_token)
+    settings.JOBBERGATE_ACCESS_TOKEN_PATH.chmod(0o600)
 
     if token_set.refresh_token is not None:
         logger.debug(f"Caching refresh token at {settings.JOBBERGATE_REFRESH_TOKEN_PATH}")
         settings.JOBBERGATE_REFRESH_TOKEN_PATH.write_text(token_set.refresh_token)
+        settings.JOBBERGATE_REFRESH_TOKEN_PATH.chmod(0o600)
 
 
 def clear_token_cache():

--- a/jobbergate-cli/tests/test_auth.py
+++ b/jobbergate-cli/tests/test_auth.py
@@ -206,9 +206,11 @@ def test_save_tokens_to_cache__success(make_token, tmp_path, mocker):
 
     assert access_token_path.exists()
     assert access_token_path.read_text() == access_token
+    assert access_token_path.stat().st_mode & 0o777 == 0o600
 
     assert refresh_token_path.exists()
     assert refresh_token_path.read_text() == refresh_token
+    assert access_token_path.stat().st_mode & 0o777 == 0o600
 
 
 def test_save_tokens_to_cache__only_saves_access_token_if_refresh_token_is_not_defined(make_token, tmp_path, mocker):


### PR DESCRIPTION
… for security

#### What
Changed the code so that it produces a file that only the current user can read/write.

#### Why
This will keep other users from using the token to impersonate this user.

`Task`: https://app.clickup.com/t/18022949/PFT-1022

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
