### PR TITLE
Implement endpoint to patch the application files individually

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Added endpoint to update the application files individually
 
 3.5.0-alpha.0 -- 2023-03-28
 ---------------------------


### PR DESCRIPTION
#### What
This PR implements one endpoint to patch any application file individually. Any application file, i.e. the config, the source and the template files can be patched separately. Example:

```python
response = await client.patch(
        f"/jobbergate/applications/{inserted_id}/upload/individually",
        files={
            "template_file": open(dummy_template_file, "rb"),
            "source_file": open(dummy_source_file, "rb"),
            "config_file": open(dummy_config_file, "rb"),
        },
    )
```

This example shows all the three types of files being updated but it is not limited to it. Any of them can be updated separately.

The endpoint returns 204 in case the response is successful.

#### Why
Enable fast edits by the UI

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
