### PR TITLE
PFT-939 Add endpoints to upload/download job script files

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -8,7 +8,7 @@ Unreleased
 ----------
 - Removed strict dependence between job_scripts and applications to allow deletes
 - Added functionality to archive applications and job_scripts
-- Added endpoints to upload/download the main job script file give its id
+- Added endpoints to upload/download the main job script file given its id
 
 3.5.0-alpha.2 -- 2023-04-27
 ---------------------------

--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 ----------
 - Removed strict dependence between job_scripts and applications to allow deletes
 - Added functionality to archive applications and job_scripts
+- Added endpoints to upload/download the main job script file give its id
 
 3.5.0-alpha.2 -- 2023-04-27
 ---------------------------

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -4,14 +4,19 @@ Router for the JobScript resource.
 from typing import Optional
 
 from armasec import TokenPayload
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi.responses import PlainTextResponse
 from loguru import logger
 from sqlalchemy import join, not_, select
 
 from jobbergate_api.apps.applications.application_files import ApplicationFiles
 from jobbergate_api.apps.applications.models import applications_table
 from jobbergate_api.apps.applications.schemas import ApplicationResponse
-from jobbergate_api.apps.job_scripts.job_script_files import JobScriptCreationError, JobScriptFiles
+from jobbergate_api.apps.job_scripts.job_script_files import (
+    JOBSCRIPTS_MAIN_FILE_FOLDER,
+    JobScriptCreationError,
+    JobScriptFiles,
+)
 from jobbergate_api.apps.job_scripts.models import job_scripts_table, searchable_fields, sortable_fields
 from jobbergate_api.apps.job_scripts.schemas import (
     JobScriptCreateRequest,
@@ -174,6 +179,76 @@ async def job_script_get(job_script_id: int = Query(...)):
     logger.debug(f"Job-script data: {response}")
 
     return response
+
+
+@router.patch(
+    "/job-scripts/{job_script_id}/upload",
+    status_code=status.HTTP_204_NO_CONTENT,
+    description="Endpoint to replace a job script file.",
+    dependencies=[Depends(guard.lockdown(Permissions.JOB_SCRIPTS_EDIT))],
+)
+async def job_script_replace_file_content(
+    job_script_id: int = Query(...),
+    job_script_file: UploadFile = File(...),
+):
+    """Replace the content on a job script file."""
+    logger.debug(f"Replacing the main file from {job_script_id=}")
+
+    query = job_scripts_table.select().where(job_scripts_table.c.id == job_script_id)
+    logger.trace(f"get_query = {render_sql(query)}")
+    job_script = await database.fetch_one(query)
+
+    if not job_script:
+        message = f"JobScript with id={job_script_id} was not found."
+        logger.warning(message)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
+
+    file_manager = JobScriptFiles.file_manager_factory(job_script_id)
+    file_content = job_script_file.file.read().decode("utf-8")
+
+    for s3_path in file_manager.keys():
+        root_dir = s3_path.parts[0]
+        if root_dir == JOBSCRIPTS_MAIN_FILE_FOLDER:
+            file_manager[s3_path] = file_content
+            logger.debug(f"Success replacing the main file from {job_script_id=}")
+            return None
+
+    message = f"Main file from {job_script_id=} was not found."
+    logger.warning(message)
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
+
+
+@router.get(
+    "/job-scripts/{job_script_id}/download",
+    status_code=status.HTTP_200_OK,
+    description="Endpoint to download a job script file.",
+    dependencies=[Depends(guard.lockdown(Permissions.JOB_SCRIPTS_VIEW))],
+)
+async def job_script_download_file(job_script_id: int = Query(...)):
+    """Download the job script file."""
+    logger.debug(f"Downloading main file from {job_script_id=}")
+
+    query = job_scripts_table.select().where(job_scripts_table.c.id == job_script_id)
+    logger.trace(f"get_query = {render_sql(query)}")
+    job_script = await database.fetch_one(query)
+
+    if not job_script:
+        message = f"JobScript with id={job_script_id} was not found."
+        logger.warning(message)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
+
+    file_manager = JobScriptFiles.file_manager_factory(job_script_id)
+
+    for s3_path in file_manager.keys():
+        root_dir = s3_path.parts[0]
+        if root_dir == JOBSCRIPTS_MAIN_FILE_FOLDER:
+            file_content = file_manager[s3_path]
+            filename = s3_path.relative_to(JOBSCRIPTS_MAIN_FILE_FOLDER).as_posix()
+            return PlainTextResponse(file_content, media_type="text/plain", headers={"filename": filename})
+
+    message = f"Main file from {job_script_id=} was not found."
+    logger.warning(message)
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
 
 
 @router.get(

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -1,6 +1,4 @@
-"""
-Router for the JobScript resource.
-"""
+"""Router for the JobScript resource."""
 from typing import Optional
 
 from armasec import TokenPayload
@@ -8,6 +6,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, 
 from fastapi.responses import PlainTextResponse
 from loguru import logger
 from sqlalchemy import join, not_, select
+from sqlalchemy.sql import func
 
 from jobbergate_api.apps.applications.application_files import ApplicationFiles
 from jobbergate_api.apps.applications.models import applications_table
@@ -210,6 +209,12 @@ async def job_script_replace_file_content(
         root_dir = s3_path.parts[0]
         if root_dir == JOBSCRIPTS_MAIN_FILE_FOLDER:
             file_manager[s3_path] = file_content
+            update_query = (
+                job_scripts_table.update()
+                .where(job_scripts_table.c.id == job_script["id"])
+                .values(updated_at=func.now())
+            )
+            await database.execute(update_query)
             logger.debug(f"Success replacing the main file from {job_script_id=}")
             return None
 


### PR DESCRIPTION
#### What

* We need to add endpoints that can support the file editors until the Jobbergate Data Restructure project is complete.
* These endpoints should not be used to add additional files or to delete files that have been added.
* These will be temporary endpoints that should only be consumed by the frontend.

#### Why
Enhance usability on the UI.

`Task`: https://app.clickup.com/t/18022949/PFT-939

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
