### PR TITLE
ASP-2110 Patch link to the application base module

### DIFF
--- a/jobbergate-docs/CHANGELOG.rst
+++ b/jobbergate-docs/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-docs
 
 Unreleased
 ----------
+- Patched the broken link to the application base module source code
 
 3.5.0-alpha.3 -- 2023-05-08
 ---------------------------

--- a/jobbergate-docs/src/developer_guide/jobbergate_py.rst
+++ b/jobbergate-docs/src/developer_guide/jobbergate_py.rst
@@ -21,7 +21,7 @@ Each Application Source script must define exactly one class named
 
 This class should be a regular python class that inherits from the
 ``JobbergateApplicationBase``. This base class is imported from
-`the application_base module`_.
+`the application_base module <https://github.com/omnivector-solutions/jobbergate/blob/main/jobbergate-cli/jobbergate_cli/subapps/applications/application_base.py>`_.
 
 The ``JobbergateApplication`` implementation may be a simple or complex as needed by
 the user. However, it must define a ``mainflow()`` method which is the first of the


### PR DESCRIPTION
#### What
Fix the broken link to the application base module source code

#### Why
It was resulting in a 404 page from GitHub.

`Task`: https://jira.scania.com/browse/ASP-2110

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
