### PR TITLE
ASP-3471 Make the signal handling backward compatible on next-gen Jobbergate

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,8 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Added functionality to make make the signal job property on job submissions backward compatible with legacy applications
+
 
 3.5.0-alpha.3 -- 2023-05-08
 ---------------------------

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -1,6 +1,7 @@
 """
 JobSubmission resource schema.
 """
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Literal, Optional
@@ -289,8 +290,9 @@ class JobProperties(BaseModel, extra=Extra.forbid):
 
         See test_backward_compatibility_on_signal_parameter for usage examples.
         """
-        if isinstance(value, str) and ":" in value and "B" in value.split(":", 1)[0]:
-            return value.replace("B", "", 1).lstrip(":")
+        if value:
+            value = re.sub(r"^B:", "", value)
+            value = re.sub(r"^BR:|^RB:", r"R:", value)
         return value
 
 

--- a/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_properties_parser.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/job_submissions/test_properties_parser.py
@@ -736,3 +736,25 @@ class TestRequeueParameter:
         actual_dict = jobscript_to_dict(jobscript)
 
         assert actual_dict == desired_dict
+
+
+@pytest.mark.parametrize(
+    "input, expected_result",
+    (
+        (None, None),
+        ("USR1@7200", "USR1@7200"),
+        ("B:USR1@7200", "USR1@7200"),
+        ("R:USR1@7200", "R:USR1@7200"),
+        ("RB:USR1@7200", "R:USR1@7200"),
+        ("BR:USR1@7200", "R:USR1@7200"),
+        ("B:BBB", "BBB"),  # a silly case, but let's assert that just the B on the left side is removed
+    ),
+)
+def test_backward_compatibility_on_signal_parameter(input, expected_result):
+    """
+    Test backward compatibility on signal parameter.
+
+    It is expected to remove the 'B' from the prefix while preserving any other, like the 'R'.
+    """
+    actual_result = JobProperties(signal=input).signal
+    assert actual_result == expected_result


### PR DESCRIPTION
#### What
Modify the business logic on the Jobbergate API to remove the `B:` syntax from the signal value when it is detected.

#### Why
As a Jobbergate maintainer, I need to implement additional business logic when processing the `--signal` batch parameter on the Jobbergate back-end to ensure backward compatibility with legacy applications.

`Task`: https://jira.scania.com/browse/ASP-3471

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
