### PR TITLE
Updated job_scripts endpoints to allow creation without application

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Modified API to allow Job Script creation without parent application
 
 3.5.0a4 -- 2023-06-12
 ---------------------

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/job_script_files.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/job_script_files.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
 from buzz import Buzz, require_condition
+from fastapi import UploadFile
 from file_storehouse import FileManager
 from jinja2 import Template
 from loguru import logger
@@ -145,6 +146,18 @@ class JobScriptFiles(BaseModel):
         Obtain the main file with this helper property.
         """
         return self.files.get(self.main_file_path)
+
+    @classmethod
+    def get_from_single_upload_file(cls, upload_file: UploadFile):
+        """
+        Initialize a JobScriptFiles from a single upload file
+        """
+        logger.debug("Creating JobScriptFiles from single upload file")
+        main_file_path = Path(".", upload_file.filename)
+        return cls(
+            main_file_path=main_file_path,
+            files={main_file_path: upload_file.file.read().decode("utf-8")},
+        )
 
     @classmethod
     def get_from_s3(cls, job_script_id: int):

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/job_script_files.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/job_script_files.py
@@ -150,7 +150,7 @@ class JobScriptFiles(BaseModel):
     @classmethod
     def get_from_single_upload_file(cls, upload_file: UploadFile):
         """
-        Initialize a JobScriptFiles from a single upload file
+        Initialize a JobScriptFiles from a single upload file.
         """
         logger.debug("Creating JobScriptFiles from single upload file")
         main_file_path = Path(".", upload_file.filename)

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -89,7 +89,11 @@ async def job_script_create(
     identity_claims = IdentityClaims.from_token_payload(token_payload)
 
     create_dict = dict(
-        **{k: v for (k, v) in job_script.dict(exclude_unset=True).items() if k not in ("param_dict", "sbatch_params")},
+        **{
+            k: v
+            for (k, v) in job_script.dict(exclude_unset=True).items()
+            if k not in ("param_dict", "sbatch_params")
+        },
         job_script_owner_email=identity_claims.email,
     )
 

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -190,7 +190,7 @@ async def job_script_get(job_script_id: int = Query(...)):
 
 @router.post(
     "/job-scripts/{job_script_id}/upload",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_200_OK,
     description="Endpoint to upload a new job script file.",
     dependencies=[Depends(guard.lockdown(Permissions.JOB_SCRIPTS_EDIT))],
 )
@@ -220,7 +220,7 @@ async def job_script_create_file_content(
     )
     await database.execute(update_query)
     logger.debug(f"Success creating job script files from single upload file for {job_script_id=}")
-    return None
+    return dict(message=f"Successfully uploaded {job_script_file.filename} for {job_script_id=}")
 
 
 @router.patch(

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -19,7 +19,6 @@ from jobbergate_api.apps.job_scripts.job_script_files import (
 from jobbergate_api.apps.job_scripts.models import job_scripts_table, searchable_fields, sortable_fields
 from jobbergate_api.apps.job_scripts.schemas import (
     JobScriptCreateRequest,
-    JobScriptPartialResponse,
     JobScriptResponse,
     JobScriptUpdateRequest,
 )
@@ -55,41 +54,44 @@ async def job_script_create(
     """
     logger.debug(f"Creating {job_script=}")
 
-    select_query = applications_table.select().where(applications_table.c.id == job_script.application_id)
-    logger.trace(f"select_query = {render_sql(select_query)}")
+    jobscript_files = None
+    application_name = None
+    if job_script.application_id is not None:
+        select_query = applications_table.select().where(applications_table.c.id == job_script.application_id)
+        logger.trace(f"select_query = {render_sql(select_query)}")
 
-    raw_application = await database.fetch_one(select_query)
+        raw_application = await database.fetch_one(select_query)
 
-    if not raw_application:
-        message = f"Application with id={job_script.application_id} not found."
-        logger.warning(message)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
+        if not raw_application:
+            message = f"Application with id={job_script.application_id} not found."
+            logger.warning(message)
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
 
-    application = ApplicationResponse.parse_obj(raw_application)
+        application = ApplicationResponse.parse_obj(raw_application)
+        application_name = application.application_name
 
-    if application.application_uploaded is False:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Application with id={job_script.application_id} was not uploaded.",
-        )
+        if application.application_uploaded is False:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Application with id={job_script.application_id} was not uploaded.",
+            )
+        try:
+            jobscript_files = JobScriptFiles.render_from_application(
+                application_files=ApplicationFiles.get_from_s3(application.id),
+                user_supplied_parameters=job_script.param_dict or {},
+                sbatch_params=job_script.sbatch_params or [],
+            )
+        except JobScriptCreationError as e:
+            message = str(e)
+            logger.error(message)
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
 
     identity_claims = IdentityClaims.from_token_payload(token_payload)
 
     create_dict = dict(
-        **{k: v for (k, v) in job_script.dict(exclude_unset=True).items() if k != "param_dict"},
+        **{k: v for (k, v) in job_script.dict(exclude_unset=True).items() if k not in ("param_dict", "sbatch_params")},
         job_script_owner_email=identity_claims.email,
     )
-
-    try:
-        jobscript_files = JobScriptFiles.render_from_application(
-            application_files=ApplicationFiles.get_from_s3(application.id),
-            user_supplied_parameters=job_script.param_dict,
-            sbatch_params=create_dict.pop("sbatch_params", []),
-        )
-    except JobScriptCreationError as e:
-        message = str(e)
-        logger.error(message)
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
 
     logger.debug("Inserting job_script")
 
@@ -108,7 +110,8 @@ async def job_script_create(
                     detail=message,
                 )
 
-            jobscript_files.write_to_s3(job_script_data["id"])
+            if jobscript_files:
+                jobscript_files.write_to_s3(job_script_data["id"])
 
         except INTEGRITY_CHECK_EXCEPTIONS as e:
             logger.error(f"Reverting database transaction: {str(e)}")
@@ -122,7 +125,7 @@ async def job_script_create(
 
     response = JobScriptResponse(
         **job_script_data,
-        application_name=application.application_name,
+        application_name=application_name,
         job_script_files=jobscript_files,
     )
     return response
@@ -147,6 +150,7 @@ async def job_script_get(job_script_id: int = Query(...)):
                 job_scripts_table,
                 applications_table,
                 applications_table.columns.id == job_scripts_table.columns.application_id,
+                isouter=True,
             )
         )
         .where(job_scripts_table.c.id == job_script_id)
@@ -178,6 +182,41 @@ async def job_script_get(job_script_id: int = Query(...)):
     logger.debug(f"Job-script data: {response}")
 
     return response
+
+
+@router.post(
+    "/job-scripts/{job_script_id}/upload",
+    status_code=status.HTTP_204_NO_CONTENT,
+    description="Endpoint to upload a new job script file.",
+    dependencies=[Depends(guard.lockdown(Permissions.JOB_SCRIPTS_EDIT))],
+)
+async def job_script_create_file_content(
+    job_script_id: int = Query(...),
+    job_script_file: UploadFile = File(...),
+):
+    """Create a job script file (only if the job script has none)."""
+    logger.debug(f"Creating the main file for {job_script_id=}")
+
+    query = job_scripts_table.select().where(job_scripts_table.c.id == job_script_id)
+    logger.trace(f"get_query = {render_sql(query)}")
+    job_script = await database.fetch_one(query)
+
+    if not job_script:
+        message = f"JobScript with id={job_script_id} was not found."
+        logger.warning(message)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
+
+    jobscript_files = JobScriptFiles.get_from_single_upload_file(job_script_file)
+    jobscript_files.write_to_s3(job_script_id, remove_previous_files=True)
+
+    update_query = (
+        job_scripts_table.update()
+        .where(job_scripts_table.c.id == job_script["id"])
+        .values(updated_at=func.now())
+    )
+    await database.execute(update_query)
+    logger.debug(f"Success creating job script files from single upload file for {job_script_id=}")
+    return None
 
 
 @router.patch(
@@ -259,7 +298,7 @@ async def job_script_download_file(job_script_id: int = Query(...)):
 @router.get(
     "/job-scripts",
     description="Endpoint to list job_scripts",
-    responses=ok_response(JobScriptPartialResponse),
+    responses=ok_response(JobScriptResponse),
 )
 async def job_script_list(
     pagination: Pagination = Depends(),
@@ -290,6 +329,7 @@ async def job_script_list(
             job_scripts_table,
             applications_table,
             applications_table.c.id == job_scripts_table.c.application_id,
+            isouter=True,
         )
     )
     identity_claims = IdentityClaims.from_token_payload(token_payload)
@@ -307,7 +347,7 @@ async def job_script_list(
         query = query.order_by(job_scripts_table.c.id.asc())
 
     logger.debug(f"Query = {render_sql(query)}")
-    return await package_response(JobScriptPartialResponse, query, pagination)
+    return await package_response(JobScriptResponse, query, pagination)
 
 
 @router.delete(

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/schemas.py
@@ -71,7 +71,7 @@ class JobScriptCreateRequest(BaseModel):
 
     job_script_name: str
     job_script_description: Optional[str]
-    application_id: int
+    application_id: Optional[int]
     sbatch_params: Optional[List[str]]
     param_dict: Optional[Dict[str, Any]]
 
@@ -95,7 +95,7 @@ class JobScriptUpdateRequest(BaseModel):
         schema_extra = job_script_meta_mapper
 
 
-class JobScriptPartialResponse(BaseModel):
+class JobScriptResponse(BaseModel):
     """
     Complete model to match database for the JobScript resource.
 
@@ -107,24 +107,11 @@ class JobScriptPartialResponse(BaseModel):
     updated_at: Optional[datetime] = None
     job_script_name: str
     job_script_description: Optional[str] = None
+    job_script_files: Optional[JobScriptFiles] = None
     job_script_owner_email: str
     application_name: Optional[str] = None
     application_id: Optional[int] = None
     is_archived: bool
-
-    class Config:
-        orm_mode = True
-        schema_extra = job_script_meta_mapper
-
-
-class JobScriptResponse(JobScriptPartialResponse):
-    """
-    Complete model to match database for the JobScript resource.
-
-    In addition to the field job_script_files from S3, for the JobScript resource.
-    """
-
-    job_script_files: JobScriptFiles
 
     class Config:
         orm_mode = True

--- a/jobbergate-api/jobbergate_api/tests/apps/job_scripts/test_routers.py
+++ b/jobbergate-api/jobbergate_api/tests/apps/job_scripts/test_routers.py
@@ -181,8 +181,8 @@ async def test_create_job_script__without_application(
     assert job_script.job_script_name == job_script_data["job_script_name"]
     assert job_script.job_script_owner_email == "owner1@org.com"
     assert job_script.job_script_description is None
-    assert job_script.job_script_files == None
-    assert job_script.application_id == None
+    assert job_script.job_script_files is None
+    assert job_script.application_id is None
     assert job_script.created_at in window
     assert job_script.updated_at in window
 

--- a/jobbergate-composed/docker-compose.yml
+++ b/jobbergate-composed/docker-compose.yml
@@ -100,6 +100,18 @@ services:
     ports:
       - 5432:5432
 
+  test-db:
+    image: postgres
+    restart: always
+    networks:
+      - jobbergate-net
+    environment:
+      - POSTGRES_PASSWORD=test-pswd
+      - POSTGRES_USER=test-user
+      - POSTGRES_DB=test-db
+    ports:
+      - 5433:5432
+
   minio:
     image: minio/minio
     networks:


### PR DESCRIPTION
#### What
Updated the job_scripts endpoints to allow creation without parent application.

#### Why
So that the UI can create a job_script with just a source file and no parent application.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
