### PR TITLE
Patch job-submission endpoints and cli schemas on 3.5.0

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Fixed job-submission endpoints to return the ones not linked to a job-script
 
 3.5.0a6 -- 2023-06-26
 ---------------------

--- a/jobbergate-api/jobbergate_api/apps/applications/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/applications/routers.py
@@ -227,18 +227,6 @@ async def application_delete(
     logger.debug(f"Preparing to delete {application_id=} from the database and S3")
 
     where_stmt = applications_table.c.id == application_id
-    get_query = applications_table.select().where(where_stmt)
-    logger.trace(f"get_query = {render_sql(get_query)}")
-
-    raw_application = await database.fetch_one(get_query)
-    if not raw_application:
-        message = f"Application {application_id=} not found."
-        logger.warning(message)
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=message,
-        )
-
     delete_query = applications_table.delete().where(where_stmt)
     logger.trace(f"delete_query = {render_sql(delete_query)}")
 

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -2,7 +2,9 @@
 from typing import Optional
 
 from armasec import TokenPayload
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query
+from fastapi import Response as FastAPIResponse
+from fastapi import UploadFile, status
 from fastapi.responses import PlainTextResponse
 from loguru import logger
 from sqlalchemy import join, not_, select
@@ -115,7 +117,6 @@ async def job_script_create(
     logger.debug("Inserting job_script")
 
     async with database.transaction():
-
         try:
             insert_query = job_scripts_table.insert().returning(job_scripts_table)
             logger.trace(f"insert_query = {render_sql(insert_query)}")
@@ -395,6 +396,8 @@ async def job_script_delete(
         # There is no need to raise an error if we try to delete a file that does not exist
         logger.warning(f"Tried to delete {job_script_id=}, but it was not found on S3.")
 
+    return FastAPIResponse(status_code=status.HTTP_204_NO_CONTENT)
+
 
 @router.put(
     "/job-scripts/{job_script_id}",
@@ -426,7 +429,6 @@ async def job_script_update(
     logger.trace(f"update_query = {render_sql(update_query)}")
 
     async with database.transaction():
-
         try:
             result = await database.fetch_one(update_query)
         except INTEGRITY_CHECK_EXCEPTIONS as e:

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -154,6 +154,7 @@ async def job_submission_get(job_submission_id: int = Query(...)):
                 job_submissions_table,
                 job_scripts_table,
                 job_submissions_table.c.job_script_id == job_scripts_table.c.id,
+                isouter=True,
             )
         )
         .where(job_submissions_table.c.id == job_submission_id)
@@ -213,6 +214,7 @@ async def job_submission_list(
             job_submissions_table,
             job_scripts_table,
             job_submissions_table.c.job_script_id == job_scripts_table.c.id,
+            isouter=True,
         )
     )
 

--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -6,6 +6,8 @@ This file keeps track of all notable changes to jobbergate-cli
 
 Unreleased
 ----------
+- Fixed schemas to support orphaned job-scripts and job-submissions
+
 
 3.5.0a6 -- 2023-06-26
 ---------------------

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -120,7 +120,7 @@ class JobScriptResponse(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     """
 
     id: int
-    application_id: int
+    application_id: Optional[int] = None
     job_script_name: str
     job_script_description: Optional[str] = None
     job_script_files: JobScriptFiles
@@ -136,7 +136,7 @@ class JobSubmissionResponse(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     """
 
     id: int
-    job_script_id: int
+    job_script_id: Optional[int] = None
     cluster_name: Optional[str] = pydantic.Field(alias="client_id")
     slurm_job_id: Optional[int]
     execution_directory: Optional[Path]


### PR DESCRIPTION
#### What
- (API) Fixed job-submission endpoints to return the ones not linked to a job-script
- (CLI) Fixed schemas to support orphaned job-scripts and job-submissions

#### Why
Minor fixes

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
