### PR TITLE
PENG-1526 Update pending orphaned job submissions

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
@@ -1,6 +1,11 @@
 """Services for the job_scripts resource, including module specific business logic."""
+from typing import Any
+
+from sqlalchemy import update
 
 from jobbergate_api.apps.job_scripts.models import JobScript, JobScriptFile
+from jobbergate_api.apps.job_submissions.constants import JobSubmissionStatus
+from jobbergate_api.apps.job_submissions.models import JobSubmission
 from jobbergate_api.apps.services import CrudService, FileService
 
 
@@ -11,6 +16,29 @@ class JobScriptCrudService(CrudService):
     Although it doesn't do anything, it fixes an error with mypy:
         error: Value of type variable "CrudModel" of "CrudService" cannot be "JobScript"
     """
+
+    async def delete(self, locator: Any) -> None:
+        """
+        Extend delete a row by locator.
+
+        Orphaned job-scripts are now allowed on Jobbergate. However, the agent
+        relies on them to submit jobs after requesting GET /agent/pending.
+        This creates a race condition and errors occur when a job-script is
+        deleted before the agent handles its submissions.
+
+        To avoid this, they are marked as reject in this scenario.
+        """
+        query = (
+            update(JobSubmission)  # type: ignore
+            .where(JobSubmission.job_script_id == locator)
+            .where(JobSubmission.status == JobSubmissionStatus.CREATED)
+            .values(
+                status=JobSubmissionStatus.REJECTED,
+                report_message="Parent job script was deleted before the submission.",
+            )
+        )
+        await self.session.execute(query)
+        await super().delete(locator)
 
 
 class JobScriptFileService(FileService):

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
@@ -37,7 +37,9 @@ class JobSubmission(CrudMixin, Base):
     See Mixin class definitions for other columns
     """
 
-    job_script_id: Mapped[int] = mapped_column(Integer, ForeignKey("job_scripts.id"), nullable=True)
+    job_script_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("job_scripts.id", ondelete="SET NULL"), nullable=True
+    )
     execution_directory: Mapped[str] = mapped_column(String, default=None, nullable=True)
     slurm_job_id: Mapped[int] = mapped_column(Integer, default=None, nullable=True)
     client_id: Mapped[str] = mapped_column(String, nullable=False, index=True)

--- a/jobbergate-api/tests/apps/job_scripts/test_services.py
+++ b/jobbergate-api/tests/apps/job_scripts/test_services.py
@@ -1,15 +1,16 @@
 """Database models for the job scripts resource."""
+from itertools import product
 from typing import Any
 
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import inspect
+
 from jobbergate_api.apps.constants import FileType
-from jobbergate_api.apps.job_scripts.services import (
-    crud_service,
-    file_service,
-)
 from jobbergate_api.apps.job_script_templates.services import crud_service as template_crud_service
+from jobbergate_api.apps.job_scripts.services import crud_service, file_service
+from jobbergate_api.apps.job_submissions.constants import JobSubmissionStatus
+from jobbergate_api.apps.job_submissions.services import crud_service as submission_crud_service
 
 
 @pytest.fixture
@@ -30,6 +31,7 @@ class TestIntegration:
         """
         with (
             crud_service.bound_session(synth_session),
+            submission_crud_service.bound_session(synth_session),
             file_service.bound_session(synth_session),
             file_service.bound_bucket(synth_bucket),
         ):
@@ -132,3 +134,44 @@ class TestIntegration:
         with pytest.raises(HTTPException) as exc_info:
             await file_service.get(script_file.parent_id, script_file.filename)
         assert exc_info.value.status_code == 404
+
+    async def test_delete_updates_related_submissions(self, script_test_data, fill_job_script_data):
+        """
+        Test all related submissions still on status CREATED are updated when parent job-script is deleted.
+        """
+        script_instance = await crud_service.create(**script_test_data)
+        target_for_deletion = await crud_service.create(**script_test_data)
+
+        expected_submissions = []
+        for status, script in product(JobSubmissionStatus, (script_instance, target_for_deletion)):
+            create_data = fill_job_script_data(
+                status=status, client_id="test-client-id", job_script_id=script.id
+            )
+            await submission_crud_service.create(**create_data)
+
+            # Modify on the expected results the business logic we expect to happen
+            if status == JobSubmissionStatus.CREATED and script == target_for_deletion:
+                create_data["status"] = JobSubmissionStatus.REJECTED
+                create_data["report_message"] = "Parent job script was deleted before the submission."
+            if script == target_for_deletion:
+                create_data["job_script_id"] = None
+
+            expected_submissions.append(create_data)
+
+        await crud_service.delete(target_for_deletion.id)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await crud_service.get(target_for_deletion.id)
+        assert exc_info.value.status_code == 404
+
+        actual_submissions = await submission_crud_service.list(sort_field="id", sort_ascending=True)
+
+        assert [s.status for s in actual_submissions] == [s.get("status") for s in expected_submissions]
+
+        assert [s.report_message for s in actual_submissions] == [
+            s.get("report_message") for s in expected_submissions
+        ]
+
+        assert [s.job_script_id for s in actual_submissions] == [
+            s.get("job_script_id") for s in expected_submissions
+        ]

--- a/jobbergate-api/tests/apps/job_submissions/test_services.py
+++ b/jobbergate-api/tests/apps/job_submissions/test_services.py
@@ -1,8 +1,6 @@
 """Database models for the job scripts resource."""
-from typing import Any
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy import inspect
 from jobbergate_api.apps.constants import FileType
 from jobbergate_api.apps.job_submissions.services import crud_service


### PR DESCRIPTION
#### What
When a job script is deleted, any job submission derivated from it whose status is still on `created` should be updated to `rejected`  with an appropriate `report_message`.


#### Why
Orphaned job-scripts are allowed after recent changes on Jobbergate, however, cluster-agent depends on them to submit the jobs after requesting GET /agent/pending . More specifically, it depends on them to get job-script files. So, there is a race condition producing errors when a job-script is deleted before its submissions are handled by the agent.

`Task`: https://app.clickup.com/t/18022949/PENG-1526

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
