### PR TITLE
PENG-1530 Add validation for template identifier

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/job_script_templates/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_script_templates/routers.py
@@ -56,7 +56,7 @@ async def job_script_template_create(
         )
 
     try:
-        new_job_template = await crud_service.create(
+        return await crud_service.create(
             owner_email=secure_session.identity_payload.email,
             **create_request.dict(exclude_unset=True),
         )
@@ -64,8 +64,6 @@ async def job_script_template_create(
         message = f"Job script template with the {create_request.identifier=} already exists"
         logger.error(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message)
-
-    return new_job_template
 
 
 @router.get(

--- a/jobbergate-api/jobbergate_api/apps/job_script_templates/services.py
+++ b/jobbergate-api/jobbergate_api/apps/job_script_templates/services.py
@@ -1,6 +1,8 @@
 """Services for the job_script_templates resource, including module specific business logic."""
 from typing import Any
 
+from buzz import require_condition
+from fastapi import status
 from sqlalchemy import not_
 from sqlalchemy.sql.expression import Select
 
@@ -9,7 +11,7 @@ from jobbergate_api.apps.job_script_templates.models import (
     JobScriptTemplateFile,
     WorkflowFile,
 )
-from jobbergate_api.apps.services import CrudService, FileService
+from jobbergate_api.apps.services import CrudModel, CrudService, FileService, ServiceError
 
 
 class JobScriptTemplateService(CrudService):
@@ -42,6 +44,20 @@ class JobScriptTemplateService(CrudService):
             query = query.where(not_(JobScriptTemplate.identifier.is_(None)))
         return query
 
+    async def create(self, **incoming_data) -> CrudModel:
+        """
+        Add a new row for the model to the database.
+        """
+        self.validate_identifier(incoming_data.get("identifier"))
+        return await super().create(**incoming_data)
+
+    async def update(self, locator: Any, **incoming_data) -> CrudModel:
+        """
+        Update a row by locator with supplied data.
+        """
+        self.validate_identifier(incoming_data.get("identifier"))
+        return await super().update(locator, **incoming_data)
+
     def locate_where_clause(self, id_or_identifier: Any) -> Any:
         """
         Locate an instance using the id or identifier field.
@@ -52,6 +68,26 @@ class JobScriptTemplateService(CrudService):
             return JobScriptTemplate.id == id_or_identifier
         else:
             raise ValueError("id_or_identifier must be a string or integer")
+
+    def validate_identifier(self, identifier: str | None) -> None:
+        """
+        Validate that the identifier is not an empty string nor composed only by digits.
+
+        Raise a ServiceError with status code 422 if the validation fails.
+
+        Many of the job-script-template endpoints use the id or identifier interchangeably
+        as a path parameter. With that, we need to ensure that the identifier is
+        not a number, as that would be identified as id.
+        """
+        if identifier is not None:
+            require_condition(
+                identifier.strip() and not identifier.isdigit(),
+                "Identifier on {} can not be a empty string nor be composed only by digits. Got {}".format(
+                    self.name, identifier
+                ),
+                raise_exc_class=ServiceError,
+                raise_kwargs=dict(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY),
+            )
 
 
 class JobScriptTemplateFileService(FileService):

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -52,12 +52,10 @@ async def job_script_create(
             detail="The token payload does not contain an email",
         )
 
-    new_job_script = await crud_service.create(
+    return await crud_service.create(
         owner_email=secure_session.identity_payload.email,
         **create_request.dict(exclude_unset=True),
     )
-
-    return new_job_script
 
 
 @router.post(

--- a/jobbergate-api/tests/apps/job_script_templates/test_services.py
+++ b/jobbergate-api/tests/apps/job_script_templates/test_services.py
@@ -42,6 +42,22 @@ class TestJobScriptTemplateCrudService:
         locator = getattr(instance, locator_attribute)
         assert await crud_service.get(locator) == instance
 
+    @pytest.mark.parametrize("identifier", ("", " ", "10"))
+    async def test_create__invalid_identifier(self, identifier, template_test_data):
+        """Test that the template is not created with an invalid identifier."""
+        template_test_data["identifier"] = identifier
+        with pytest.raises(HTTPException) as exc_info:
+            await crud_service.create(**template_test_data)
+        assert exc_info.value.status_code == 422
+
+    @pytest.mark.parametrize("identifier", ("", " ", "10"))
+    async def test_update__invalid_identifier(self, identifier, template_test_data):
+        """Test that the template is not updated with an invalid identifier."""
+        instance = await crud_service.create(**template_test_data)
+        with pytest.raises(HTTPException) as exc_info:
+            await crud_service.update(instance.id, identifier=identifier)
+        assert exc_info.value.status_code == 422
+
     @pytest.mark.parametrize("locator_attribute", ("id", "identifier"))
     async def test_delete__success(
         self,


### PR DESCRIPTION
#### What
Add validation for template identifier.

#### Why
Many CRUD operations on the job script templates accept the id or identifier just out of the box and use type check to differentiate which one to use. The drawback is that the identifier can not be composed of just numbers. We need to validate its value when creating/updating a job-script template.

`Task`: https://app.clickup.com/t/18022949/PENG-1530

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
