### PR TITLE
PENG-1546 Guarantee only one entrypoint file per job script

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
@@ -135,15 +135,14 @@ class JobScriptFileService(FileService):
             raise_exc_class=ServiceError,
             raise_kwargs=dict(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY),
         )
-        await self.validate_entrypoint_file(parent_id, filename, file_type)
+        if file_type == FileType.ENTRYPOINT:
+            await self.validate_entrypoint_file(parent_id, filename)
         return await super().upsert(parent_id, filename, upload_content, **upsert_kwargs)
 
-    async def validate_entrypoint_file(self, parent_id: int, filename: str, file_type: FileType | str):
+    async def validate_entrypoint_file(self, parent_id: int, filename: str):
         """
         Validate that the entrypoint file is unique.
         """
-        if file_type != FileType.ENTRYPOINT:
-            return
 
         file_list = await self.find_children(parent_id)
 

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
@@ -2,13 +2,16 @@
 from typing import Any, NamedTuple
 
 import pendulum
+from buzz import enforce_defined, require_condition
+from fastapi import UploadFile, status
 from loguru import logger
 from sqlalchemy import delete, func, select, update
 
+from jobbergate_api.apps.constants import FileType
 from jobbergate_api.apps.job_scripts.models import JobScript, JobScriptFile
 from jobbergate_api.apps.job_submissions.constants import JobSubmissionStatus
 from jobbergate_api.apps.job_submissions.models import JobSubmission
-from jobbergate_api.apps.services import CrudService, FileService
+from jobbergate_api.apps.services import CrudService, FileModel, FileService, ServiceError
 from jobbergate_api.config import settings
 
 
@@ -115,6 +118,51 @@ class JobScriptFileService(FileService):
     Although it doesn't do anything, it fixes an error with mypy:
         error: Value of type variable "FileModel" of "FileService" cannot be "JobScriptFile"
     """
+
+    async def upsert(
+        self,
+        parent_id: int,
+        filename: str,
+        upload_content: str | bytes | UploadFile,
+        **upsert_kwargs,
+    ) -> FileModel:
+        """
+        Upsert a file instance.
+        """
+        file_type: str = enforce_defined(
+            upsert_kwargs.get("file_type", None),
+            "File type must be defined when upserting a file.",
+            raise_exc_class=ServiceError,
+            raise_kwargs=dict(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY),
+        )
+        await self.validate_entrypoint_file(parent_id, filename, file_type)
+        return await super().upsert(parent_id, filename, upload_content, **upsert_kwargs)
+
+    async def validate_entrypoint_file(self, parent_id: int, filename: str, file_type: FileType | str):
+        """
+        Validate that the entrypoint file is unique.
+        """
+        if file_type != FileType.ENTRYPOINT:
+            return
+
+        file_list = await self.find_children(parent_id)
+
+        entry_point_names = {file.filename for file in file_list if file.file_type == FileType.ENTRYPOINT}
+
+        no_entry_point = len(entry_point_names) == 0
+        replacing_entry_point = filename in entry_point_names
+        sanity_check = len(entry_point_names) <= 1
+
+        require_condition(
+            (no_entry_point or replacing_entry_point) and sanity_check,
+            (
+                "A job script can not have more than one entry point file. "
+                "Consider deleting the existing one first. "
+                "Found: {}".format(",".join(entry_point_names))
+            ),
+            raise_exc_class=ServiceError,
+            raise_kwargs=dict(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY),
+        )
 
 
 crud_service = JobScriptCrudService(model_type=JobScript)

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
@@ -143,7 +143,6 @@ class JobScriptFileService(FileService):
         """
         Validate that the entrypoint file is unique.
         """
-
         file_list = await self.find_children(parent_id)
 
         entry_point_names = {file.filename for file in file_list if file.file_type == FileType.ENTRYPOINT}


### PR DESCRIPTION
#### What
Add business logic to guarantee job scripts have only one entry point

#### Why
Entrypoint is the file sent to slurmrest, so more than one is ambiguous and should not be allowed.

`Task`: https://app.clickup.com/t/18022949/PENG-1546

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
