### PR TITLE
Automatically clean up unused job scripts

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -313,7 +313,7 @@ async def job_script_delete_file(
     description="Endpoint to delete all unused files from the job script file storage",
     tags=["Garbage collector"],
 )
-async def job_script_template_garbage_collector(
+async def job_script_garbage_collector(
     background_tasks: BackgroundTasks,
     secure_session: SecureSession = Depends(secure_session(Permissions.JOB_SCRIPTS_EDIT)),
     bucket=Depends(s3_bucket),
@@ -328,3 +328,21 @@ async def job_script_template_garbage_collector(
         background_tasks,
     )
     return {"description": "Garbage collection started"}
+
+
+@router.delete(
+    "/clean-unused-entries",
+    status_code=status.HTTP_202_ACCEPTED,
+    description="Endpoint to automatically clean unused job scripts depending on a threshold",
+    tags=["Garbage collector"],
+)
+async def job_script_auto_clean_unused_entries(
+    background_tasks: BackgroundTasks,
+    secure_session: SecureSession = Depends(
+        secure_services(Permissions.JOB_SCRIPTS_EDIT, services=[crud_service])
+    ),
+):
+    """Automatically clean unused job scripts depending on a threshold."""
+    logger.info("Starting automatically cleanup for unused job scripts")
+    # background_tasks.add_task(crud_service.auto_clean_unused_job_scripts)
+    return {"description": "Automatically cleanup started"}

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
@@ -62,7 +62,10 @@ class JobScriptCrudService(CrudService):
         result = AutoCleanResponse(archived=set(), deleted=set())
 
         subquery = (
-            select(JobSubmission.job_script_id, func.max(JobSubmission.created_at).label("last_used"))  # type: ignore
+            select(
+                JobSubmission.job_script_id,
+                func.max(JobSubmission.created_at).label("last_used"),
+            )  # type: ignore
             .group_by(JobSubmission.job_script_id)
             .subquery()
         )

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
@@ -1,12 +1,24 @@
 """Services for the job_scripts resource, including module specific business logic."""
-from typing import Any
+from typing import Any, NamedTuple
 
-from sqlalchemy import update
+import pendulum
+from loguru import logger
+from sqlalchemy import delete, func, select, update
 
 from jobbergate_api.apps.job_scripts.models import JobScript, JobScriptFile
 from jobbergate_api.apps.job_submissions.constants import JobSubmissionStatus
 from jobbergate_api.apps.job_submissions.models import JobSubmission
 from jobbergate_api.apps.services import CrudService, FileService
+from jobbergate_api.config import settings
+
+
+class AutoCleanResponse(NamedTuple):
+    """
+    Named tuple for the response of auto_clean_unused_job_scripts.
+    """
+
+    archived: set[int]
+    deleted: set[int]
 
 
 class JobScriptCrudService(CrudService):
@@ -39,6 +51,58 @@ class JobScriptCrudService(CrudService):
         )
         await self.session.execute(query)
         await super().delete(locator)
+
+    async def auto_clean_unused_job_scripts(self) -> AutoCleanResponse:
+        """
+        Automatically clean unused job scripts depending on a threshold.
+
+        Based on the last time each job script was updated or used to create a job submission,
+        this will archived job scripts that were unarchived and delete jos script that were archived.
+        """
+        result = AutoCleanResponse(archived=set(), deleted=set())
+
+        subquery = (
+            select(JobSubmission.job_script_id, func.max(JobSubmission.created_at).label("last_used"))  # type: ignore
+            .group_by(JobSubmission.job_script_id)
+            .subquery()
+        )
+        joined_query = (
+            select(self.model_type, subquery)  # type: ignore
+            .join(subquery, subquery.c.job_script_id == self.model_type.id, isouter=True)
+            .subquery()
+        )
+
+        if days_to_delete := settings.AUTO_CLEAN_JOB_SCRIPTS_DAYS_TO_DELETE:
+            query = (
+                delete(self.model_type)  # type: ignore
+                .where(self.model_type.is_archived.is_(True))
+                .where(
+                    func.greatest(joined_query.c.updated_at, joined_query.c.last_used)
+                    < pendulum.now().subtract(days=days_to_delete)
+                )
+                .returning(self.model_type.id)
+            )
+            deleted = await self.session.execute(query)
+            result.deleted.update(row[0] for row in deleted.all())
+
+        if days_to_archive := settings.AUTO_CLEAN_JOB_SCRIPTS_DAYS_TO_ARCHIVE:
+            update_query = (
+                update(self.model_type)  # type: ignore
+                .where(self.model_type.is_archived.is_(False))
+                .where(
+                    func.greatest(joined_query.c.updated_at, joined_query.c.last_used)
+                    < pendulum.now().subtract(days=days_to_archive)
+                )
+                .values(is_archived=True)
+                .returning(self.model_type.id)
+            )
+            archived = await self.session.execute(update_query)
+            result.archived.update(row[0] for row in archived.all())
+
+        logger.debug(f"Job scripts marked as archived: {result.archived}")
+        logger.debug(f"Job scripts marked as deleted: {result.deleted}")
+
+        return result
 
 
 class JobScriptFileService(FileService):

--- a/jobbergate-api/jobbergate_api/apps/models.py
+++ b/jobbergate-api/jobbergate_api/apps/models.py
@@ -2,13 +2,13 @@
 
 from datetime import datetime
 
+import pendulum
 from inflection import tableize
 from snick import conjoin
 from sqlalchemy import Boolean, DateTime, Integer, String
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import DeclarativeBase, Mapped, declared_attr, mapped_column
-from sqlalchemy.sql import functions
 from sqlalchemy.sql.expression import Select
 
 
@@ -74,12 +74,14 @@ class TimestampMixin:
         updated_at: The date and time when the job script template was updated.
     """
 
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=functions.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=pendulum.now
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
-        default=functions.now(),
-        onupdate=functions.current_timestamp(),
+        default=pendulum.now,
+        onupdate=pendulum.now,
     )
 
 

--- a/jobbergate-api/jobbergate_api/config.py
+++ b/jobbergate-api/jobbergate_api/config.py
@@ -90,6 +90,10 @@ class Settings(BaseSettings):
     # Enable multi-tenancy so that the database is determined by the client_id in the auth token
     MULTI_TENANCY_ENABLED: bool = Field(False)
 
+    # Automatically clean up unused job scripts
+    AUTO_CLEAN_JOB_SCRIPTS_DAYS_TO_ARCHIVE: int | None
+    AUTO_CLEAN_JOB_SCRIPTS_DAYS_TO_DELETE: int | None
+
     @root_validator(pre=True)
     def remove_blank_env(cls, values):
         """

--- a/jobbergate-api/jobbergate_api/version.py
+++ b/jobbergate-api/jobbergate_api/version.py
@@ -2,9 +2,8 @@
 Provide the version of the package.
 """
 
-from importlib import metadata
-
 import tomllib
+from importlib import metadata
 
 
 def get_version_from_metadata() -> str:

--- a/jobbergate-api/tests/apps/job_scripts/test_routers.py
+++ b/jobbergate-api/tests/apps/job_scripts/test_routers.py
@@ -644,3 +644,10 @@ class TestJobScriptFiles:
         inject_security_header(requester_email, Permissions.JOB_SCRIPTS_EDIT)
         response = await client.delete(f"jobbergate/job-scripts/{parent_id}/upload/{job_script_filename}")
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_auto_clean_unused_entries(client, tester_email, inject_security_header):
+    """Test that unused job scripts are automatically cleaned."""
+    inject_security_header(tester_email, Permissions.JOB_SCRIPTS_EDIT)
+    response = await client.delete("jobbergate/job-scripts/clean-unused-entries")
+    assert response.status_code == status.HTTP_202_ACCEPTED

--- a/jobbergate-api/tests/apps/test_services.py
+++ b/jobbergate-api/tests/apps/test_services.py
@@ -74,16 +74,14 @@ class TestCrudService:
         """
         Test that the ``create()`` method successfully creates an instance of the served model.
         """
-        with time_frame() as window:
-            instance = await dummy_crud_service.create(
-                name="test-name",
-                description="test-description",
-                owner_email=tester_email,
-            )
+
+        instance = await dummy_crud_service.create(
+            name="test-name",
+            description="test-description",
+            owner_email=tester_email,
+        )
 
         assert instance.owner_email == tester_email
-        assert instance.created_at in window
-        assert instance.updated_at in window
         assert isinstance(instance.id, int)
 
     async def test_count__success(


### PR DESCRIPTION
#### What
* An automated process is created to perform the cleanup
* Job scripts that have not been used in one week are archived
* Job scripts that have been archived for one month are deleted

#### Why
As a jobbergate users, I want my unused job scripts to automatically be cleaned up if they are not used for some time so that stale job scripts don't clutter the system.

`Task`: https://jira.scania.com/browse/ASP-3417

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
