### PR TITLE
Fix: Search on job-scripts (API)

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Fix search when listing job-scripts
 
 4.0.0a1 -- 2023-08-15
 ---------------------

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/models.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/models.py
@@ -55,13 +55,6 @@ class JobScript(CrudMixin, Base):
     )
 
     @classmethod
-    def searchable_fields(cls):
-        """
-        Add parent_template_id as a searchable field.
-        """
-        return {cls.parent_template_id, *super().searchable_fields()}
-
-    @classmethod
     def sortable_fields(cls):
         """
         Add parent_template_id as a sortable field.

--- a/jobbergate-api/tests/apps/test_models.py
+++ b/jobbergate-api/tests/apps/test_models.py
@@ -1,0 +1,13 @@
+"""Test the the models."""
+import pytest
+from sqlalchemy import String
+
+from jobbergate_api.apps.job_script_templates.models import JobScriptTemplate
+from jobbergate_api.apps.job_scripts.models import JobScript
+from jobbergate_api.apps.job_submissions.models import JobSubmission
+
+
+@pytest.mark.parametrize("Model", (JobScriptTemplate, JobScript, JobSubmission))
+def test_searchable_fields_are_strings(Model):
+    """Test that the searchable fields are strings, so search will work."""
+    assert all(isinstance(c.type, String) for c in Model.searchable_fields())


### PR DESCRIPTION
#### What
Remove `parent_template_id` from the searchable fields on job-scripts. Since it is of type `int`, it was resulting in an internal server error.

#### Why
Fix search when requesting a list of job-scripts.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
