### PR TITLE
Patch: remove path info when uploading files (CLI)

### DIFF
--- a/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
@@ -224,7 +224,7 @@ def upload_application(
                     expect_response=False,
                     abort_message="Request to upload application files was not accepted by the API",
                     support=True,
-                    files={"upload_file": (relative_template_path.as_posix(), template_file, "text/plain")},
+                    files={"upload_file": (relative_template_path.name, template_file, "text/plain")},
                 ),
             )
             if response_code != 200:

--- a/jobbergate-cli/tests/subapps/applications/test_tools.py
+++ b/jobbergate-cli/tests/subapps/applications/test_tools.py
@@ -286,8 +286,17 @@ class TestUploadApplicationFiles:
         dummy_context,
         mocked_routes,
     ):
-        with mocked_routes:
+        with mocked_routes as routes:
             result = upload_application(dummy_context, dummy_application_dir, self.application_id)
+
+            # Ensure just the filename is included, nothing extra from path
+            filename_check = b'filename="jobbergate.py"\r\n'
+            assert routes["upload_workflow"].call_count == 1
+            assert filename_check in routes["upload_workflow"].calls[0].request.content
+
+            filename_check = b'filename="job-script-template.py.j2"\r\n'
+            assert routes["upload_template"].call_count == 1
+            assert filename_check in routes["upload_template"].calls[0].request.content
 
         assert result is True
 


### PR DESCRIPTION
#### What
* Remove path info when uploading files to the API (CLI), just the filename should be included on the request.

#### Why
* Ensure backward compatibility.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
