### PR TITLE
Fix: make name optional on update job-script

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to jobbergate-api
 Unreleased
 ----------
 - Fix the bucket name when multi tenancy is enabled
+- Fix job script update by making name an optional argument
 
 4.0.0a3 -- 2023-08-24
 ---------------------

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/schemas.py
@@ -100,11 +100,13 @@ class RenderFromTemplateRequest(BaseModel):
         schema_extra = job_script_meta_mapper
 
 
-class JobScriptUpdateRequest(JobScriptCreateRequest):
+class JobScriptUpdateRequest(BaseModel):
     """
     Request model for updating JobScript instances.
     """
 
+    name: str | None
+    description: str | None
     is_archived: bool | None
 
     class Config:

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -224,7 +224,7 @@ def update(
         ...,
         help="The id of the job script to update",
     ),
-    name: str = typer.Option(
+    name: Optional[str] = typer.Option(
         None,
         help="Optional new name of the job script.",
     ),


### PR DESCRIPTION
#### What
Make name optional when updating a job-script

#### Why
Bug fix.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
