### PR TITLE
fix-cli: refresh token is refreshed

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
 
 4.0.0a5 -- 2023-08-29
 ---------------------
+- Fixed refresh token not being updated on cache after token refresh
 
 4.0.0a4 -- 2023-08-25
 ---------------------

--- a/jobbergate-cli/jobbergate_cli/auth.py
+++ b/jobbergate-cli/jobbergate_cli/auth.py
@@ -237,6 +237,8 @@ def refresh_access_token(ctx: JobbergateContext, token_set: TokenSet):
     )
 
     token_set.access_token = refreshed_token_set.access_token
+    if refreshed_token_set.refresh_token is not None:
+        token_set.refresh_token = refreshed_token_set.refresh_token
 
 
 def fetch_auth_tokens(ctx: JobbergateContext) -> TokenSet:


### PR DESCRIPTION
#### What
Refresh token is refreshed as well.

#### Why
If the refresh token is not updated together with the access token, the section will be closed sooner and users will need to log in more often.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
