### PR TITLE
fix: backward compatibility on organization id (API)

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Add backward compatibility for organization_id on the identity payload
 
 4.0.0a6 -- 2023-08-31
 ---------------------

--- a/jobbergate-api/jobbergate_api/security.py
+++ b/jobbergate-api/jobbergate_api/security.py
@@ -82,7 +82,10 @@ class IdentityPayload(TokenPayload):
         }
         """
         organization_dict = values.pop("organization", None)
-        if organization_dict is None:
+        if organization_dict is None or isinstance(organization_dict, str):
+            # String is accepted for backwards compatibility with previous Keycloak setup
+            # Code downstream ensures that the organization_id is not None if necessary
+            logger.warning(f"Invalid organization payload: {organization_dict}")
             return values
 
         if not isinstance(organization_dict, dict):


### PR DESCRIPTION
#### What
* fix: backward compatibility on organization id

#### Why
* Make it compatible with previous Keycloak instances

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
