### PR TITLE
ASP-3752 Validate existing Jobbergate applications on NextGen Jobbergate v4

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
 
 4.0.0a7 -- 2023-09-05
 ---------------------
+- Fixed supporting files output names
 
 4.0.0a6 -- 2023-08-31
 ---------------------

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -68,13 +68,25 @@ class JobbergateConfig(pydantic.BaseModel, extra=pydantic.Extra.allow):
     template_files: Optional[List[Path]]
     default_template: Optional[str] = None
     output_directory: Path = Path(".")
-    supporting_files_output_name: Optional[Dict[str, Any]] = None
+    supporting_files_output_name: Optional[Dict[str, List[str]]] = None
     supporting_files: Optional[List[str]] = None
 
     # For some reason, we support the application_config being about to override the *required*
     # job_script_name parameter that is passed at job_script creation time.
     # TODO: Find if this functionality is every used, and, if not, remove it immediately.
     job_script_name: Optional[str] = None
+
+    @pydantic.root_validator(pre=True)
+    def compute_extra_settings(cls, values):
+        """
+        Compute missing values and extra operations to enhance the user experience and backward compatibility.
+        """
+        if values.get("supporting_files_output_name"):
+            for k, v in values["supporting_files_output_name"].items():
+                if isinstance(v, str):
+                    values["supporting_files_output_name"][k] = [v]
+
+        return values
 
 
 class JobbergateApplicationConfig(pydantic.BaseModel):


### PR DESCRIPTION
#### What
Fix compatibility

#### Why
As a Jobbergate maintainer, I need to make sure that existing Jobbergate applications can run with full function on the new data model on the Nextgen Jobbergate platform.

`Task`: https://jira.scania.com/browse/ASP-3752

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
