### PR TITLE
ASP-3323 remove frame around login url

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 Unreleased
 ----------
+- Added an alternative way to present to login url on narrow terminals
 
 4.0.0 -- 2023-09-14
 -------------------

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -22,7 +22,7 @@ HIDDEN_FIELDS = [
     "created_at",
     "updated_at",
     "execution_parameters",
-    "job_script"
+    "job_script",
 ]
 
 


### PR DESCRIPTION
#### What
Add an alternative way to present the login URL to the users on narrow terminals

#### Why
So it can be copy-pasted into the browser without editing the clipboard contents (removing extra characters from the panel).

`Task`: https://jira.scania.com/browse/ASP-3323

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
