### PR TITLE
fix: help text of id on three cli commands

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 Unreleased
 ----------
+- Fixed help information for id on `get-job-script`, `download-job-script`, and `get-job-submission` commands
 
 4.1.0a1 -- 2023-10-02
 ---------------------

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -100,7 +100,7 @@ def list_all(
 @handle_abort
 def get_one(
     ctx: typer.Context,
-    id: int = typer.Option(int, help="The specific id of the job script."),
+    id: int = typer.Option(..., help="The specific id of the job script."),
 ):
     """
     Get a single job script by id.
@@ -336,7 +336,7 @@ def show_files(
 @handle_abort
 def download_files(
     ctx: typer.Context,
-    id: int = typer.Option(int, help="The specific id of the job script."),
+    id: int = typer.Option(..., help="The specific id of the job script."),
 ):
     """
     Download the files from a job script to the current working directory.

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -171,7 +171,7 @@ def list_all(
 @handle_abort
 def get_one(
     ctx: typer.Context,
-    id: int = typer.Option(int, help="The specific id of the job submission."),
+    id: int = typer.Option(..., help="The specific id of the job submission."),
 ):
     """
     Get a single job submission by id


### PR DESCRIPTION
#### What
The help text was a bit confusing, indicating that the id was `[default: (dynamic)]` when it should be `[default: None] [required]`. See previous and new messages below, respectively:

```
$ jobbergate download-job-script --help
                                                                                              
 Usage: jobbergate download-job-script [OPTIONS]                                              
                                                                                              
 Download job script files.                                                                   
                                                                                              
╭─ Options ──────────────────────────────────────────────────────────────────────────────────╮
│ --id          INTEGER  The specific id of the job script. [default: (dynamic)]             │
│ --help                 Show this message and exit.                                         │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```

```
$ jobbergate download-job-script --help
                                                                                              
 Usage: jobbergate download-job-script [OPTIONS]                                              
                                                                                              
 Download job script files.                                                                   
                                                                                              
╭─ Options ──────────────────────────────────────────────────────────────────────────────────╮
│ *  --id          INTEGER  The specific id of the job script. [default: None] [required]    │
│    --help                 Show this message and exit.                                      │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```
#### Why
Enhance user experience.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
