### PR TITLE
PENG-1753 Make runtime config optional when uploading workflow file

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Made `runtime_config` optional when uploading a workflow file
 
 4.1.0a1 -- 2023-10-02
 ---------------------


### PR DESCRIPTION
#### What
The runtime config is optional when uploading a workflow file for a job script template.

#### Why
In order to support editing of the workflow file, we need the runtime config to be optional when a user uploads a workflow file.

`Task`: https://app.clickup.com/t/18022949/PENG-1753

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
