### PR TITLE
[ASP-3322] Add support to both id and identifier

### DIFF
--- a/jobbergate-cli/CHANGELOG.rst
+++ b/jobbergate-cli/CHANGELOG.rst
@@ -10,6 +10,8 @@ Unreleased
 - Fixed help information for id on `get-job-script`, `download-job-script`, and `get-job-submission` commands
 - Added short arguments for backward compatiblity
 - Ignore username and password arguments if provided, aiming to keep backward compatibility
+- Add support to select applications by identifier in update and delete commands
+- Add show-files command to compat mode
 
 4.1.0a1 -- 2023-10-02
 ---------------------

--- a/jobbergate-cli/jobbergate_cli/compat.py
+++ b/jobbergate-cli/jobbergate_cli/compat.py
@@ -16,6 +16,7 @@ from jobbergate_cli.subapps.job_scripts.app import download_files as download_fi
 from jobbergate_cli.subapps.job_scripts.app import get_one as get_job_script
 from jobbergate_cli.subapps.job_scripts.app import list_all as list_job_scripts
 from jobbergate_cli.subapps.job_scripts.app import render as render_job_script
+from jobbergate_cli.subapps.job_scripts.app import show_files as show_files
 from jobbergate_cli.subapps.job_scripts.app import update as update_job_script
 from jobbergate_cli.subapps.job_submissions.app import create as create_job_submission
 from jobbergate_cli.subapps.job_submissions.app import delete as delete_job_submission
@@ -80,6 +81,10 @@ def add_legacy_compatible_commands(app: typer.Typer):
         name="download-job-script",
         help="Download job script files.",
     )(download_files_job_script)
+    app.command(
+        name="show-job-script-files",
+        help="Show job script files.",
+    )(show_files)
 
     # Job Submissions
     app.command(

--- a/jobbergate-cli/tests/subapps/applications/test_tools.py
+++ b/jobbergate-cli/tests/subapps/applications/test_tools.py
@@ -287,7 +287,7 @@ class TestUploadApplicationFiles:
         mocked_routes,
     ):
         with mocked_routes as routes:
-            result = upload_application(dummy_context, dummy_application_dir, self.application_id)
+            result = upload_application(dummy_context, dummy_application_dir, self.application_id, None)
 
             # Ensure just the filename is included, nothing extra from path
             filename_check = b'filename="jobbergate.py"\r\n'
@@ -304,28 +304,28 @@ class TestUploadApplicationFiles:
     def test_upload_application__fails_directory_does_not_exists(self, dummy_application_dir, dummy_context):
         application_path = dummy_application_dir / "does-not-exist"
         with pytest.raises(Abort, match="Application directory"):
-            upload_application(dummy_context, application_path, self.application_id)
+            upload_application(dummy_context, application_path, self.application_id, None)
 
     @respx.mock(assert_all_mocked=True)
     def test_upload_application__fails_config_file_not_found(self, dummy_application_dir, dummy_context):
         file_path = dummy_application_dir / JOBBERGATE_APPLICATION_CONFIG_FILE_NAME
         file_path.unlink()
         with pytest.raises(Abort, match="Application config file"):
-            upload_application(dummy_context, dummy_application_dir, self.application_id)
+            upload_application(dummy_context, dummy_application_dir, self.application_id, None)
 
     @respx.mock(assert_all_mocked=True)
     def test_upload_application__fails_module_file_not_found(self, dummy_application_dir, dummy_context):
         file_path = dummy_application_dir / JOBBERGATE_APPLICATION_MODULE_FILE_NAME
         file_path.unlink()
         with pytest.raises(Abort, match="Application module file"):
-            upload_application(dummy_context, dummy_application_dir, self.application_id)
+            upload_application(dummy_context, dummy_application_dir, self.application_id, None)
 
     @respx.mock(assert_all_mocked=True)
     def test_upload_application__fails_no_template_found(self, dummy_application_dir, dummy_context):
         file_path = dummy_application_dir / "templates" / "job-script-template.py.j2"
         file_path.unlink()
         with pytest.raises(Abort, match="No template files found in"):
-            upload_application(dummy_context, dummy_application_dir, self.application_id)
+            upload_application(dummy_context, dummy_application_dir, self.application_id, None)
 
 
 class TestDownloadApplicationFiles:

--- a/jobbergate-cli/tests/test_compat.py
+++ b/jobbergate-cli/tests/test_compat.py
@@ -42,6 +42,7 @@ def test_list_all__makes_request_and_renders_results():
             "create-job-submission",
             "delete-job-submission",
             "download-job-script",
+            "show-job-script-files",
         ]
     )
 


### PR DESCRIPTION
#### What
Update the commands `update` and `delete` `application` to accept both `id` and `identifier` as identification for the resource.
Also add the command `show-files` to the compat mode.

#### Why
To keep compatibility with the legacy Jobbergate.

`Task`: https://jira.scania.com/browse/ASP-3322

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
