### PR TITLE
Patch-API: avoid committing on GET endpoints

### DIFF
--- a/jobbergate-api/CHANGELOG.rst
+++ b/jobbergate-api/CHANGELOG.rst
@@ -6,6 +6,8 @@ This file keeps track of all notable changes to jobbergate-api
 
 Unreleased
 ----------
+- Changed internals to avoid committing to the database when a GET request is made
+- Added extra settings to allow profiling and tracing on sentry
 
 4.1.0a2 -- 2023-10-10
 ---------------------

--- a/jobbergate-api/jobbergate_api/apps/dependencies.py
+++ b/jobbergate-api/jobbergate_api/apps/dependencies.py
@@ -119,6 +119,7 @@ def service_factory(session: AsyncSession, bucket: Bucket) -> Iterator[Services]
 def secure_services(
     *scopes: str,
     permission_mode: PermissionMode = PermissionMode.ALL,
+    commit: bool = True,
     ensure_email: bool = False,
     ensure_client_id: bool = False,
 ):
@@ -131,6 +132,7 @@ def secure_services(
             secure_session(
                 *scopes,
                 permission_mode=permission_mode,
+                commit=commit,
                 ensure_email=ensure_email,
                 ensure_organization=settings.MULTI_TENANCY_ENABLED is True,
                 ensure_client_id=ensure_client_id,

--- a/jobbergate-api/jobbergate_api/apps/job_script_templates/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_script_templates/routers.py
@@ -62,7 +62,7 @@ async def job_script_template_create(
 )
 async def job_script_template_get(
     id_or_identifier: int | str = Path(),
-    secure_services: SecureService = Depends(secure_services(Permissions.JOB_TEMPLATES_VIEW)),
+    secure_services: SecureService = Depends(secure_services(Permissions.JOB_TEMPLATES_VIEW, commit=False)),
 ):
     """Get a job script template by id or identifier."""
     logger.info(f"Getting job script template with {id_or_identifier=}")
@@ -77,7 +77,7 @@ async def job_script_template_get(
 async def job_script_template_get_list(
     list_params: ListParams = Depends(),
     include_null_identifier: bool = Query(False),
-    secure_services: SecureService = Depends(secure_services(Permissions.JOB_TEMPLATES_VIEW)),
+    secure_services: SecureService = Depends(secure_services(Permissions.JOB_TEMPLATES_VIEW, commit=False)),
 ):
     """Get a list of job script templates."""
     logger.debug("Preparing to list job script templates")
@@ -143,7 +143,7 @@ async def job_script_template_delete(
 async def job_script_template_get_file(
     id_or_identifier: int | str = Path(),
     file_name: str = Path(),
-    secure_services: SecureService = Depends(secure_services(Permissions.JOB_TEMPLATES_VIEW)),
+    secure_services: SecureService = Depends(secure_services(Permissions.JOB_TEMPLATES_VIEW, commit=False)),
 ):
     """
     Get a job script template file by id or identifier.
@@ -221,7 +221,7 @@ async def job_script_template_delete_file(
 )
 async def job_script_workflow_get_file(
     id_or_identifier: int | str = Path(),
-    secure_services: SecureService = Depends(secure_services(Permissions.JOB_TEMPLATES_VIEW)),
+    secure_services: SecureService = Depends(secure_services(Permissions.JOB_TEMPLATES_VIEW, commit=False)),
 ):
     """
     Get a workflow file by id or identifier.

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -145,7 +145,7 @@ async def job_script_create_from_template(
 )
 async def job_script_get(
     id: int = Path(),
-    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SCRIPTS_VIEW)),
+    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SCRIPTS_VIEW, commit=False)),
 ):
     """Get a job script by id."""
     logger.info(f"Getting job script {id=}")
@@ -164,7 +164,7 @@ async def job_script_get_list(
         None,
         description="Filter job-scripts by the job-script-template-id they were created from.",
     ),
-    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SCRIPTS_VIEW)),
+    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SCRIPTS_VIEW, commit=False)),
 ):
     """Get a list of job scripts."""
     logger.debug("Preparing to list job scripts")
@@ -227,7 +227,7 @@ async def job_script_delete(
 async def job_script_get_file(
     id: int = Path(...),
     file_name: str = Path(...),
-    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SCRIPTS_VIEW)),
+    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SCRIPTS_VIEW, commit=False)),
 ):
     """
     Get a job script file.

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/routers.py
@@ -90,7 +90,7 @@ async def job_submission_create(
 )
 async def job_submission_get(
     id: int = Path(...),
-    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SUBMISSIONS_VIEW)),
+    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SUBMISSIONS_VIEW, commit=False)),
 ):
     """Return the job_submission given it's id."""
     logger.debug(f"Getting job submission {id=}")
@@ -119,7 +119,7 @@ async def job_submission_get_list(
         None,
         description="Filter job-submissions by the job-script-id they were created from.",
     ),
-    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SUBMISSIONS_VIEW)),
+    secure_services: SecureService = Depends(secure_services(Permissions.JOB_SUBMISSIONS_VIEW, commit=False)),
 ):
     """List job_submissions for the authenticated user."""
     logger.debug("Fetching job submissions")
@@ -236,7 +236,7 @@ async def job_submission_agent_update(
 )
 async def job_submissions_agent_pending(
     secure_services: SecureService = Depends(
-        secure_services(Permissions.JOB_SUBMISSIONS_VIEW, ensure_client_id=True)
+        secure_services(Permissions.JOB_SUBMISSIONS_VIEW, commit=False, ensure_client_id=True)
     ),
 ):
     """Get a list of pending job submissions for the cluster-agent."""
@@ -262,7 +262,7 @@ async def job_submissions_agent_pending(
 )
 async def job_submissions_agent_active(
     secure_services: SecureService = Depends(
-        secure_services(Permissions.JOB_SUBMISSIONS_VIEW, ensure_client_id=True)
+        secure_services(Permissions.JOB_SUBMISSIONS_VIEW, commit=False, ensure_client_id=True)
     ),
 ):
     """Get a list of active job submissions for the cluster-agent."""

--- a/jobbergate-api/jobbergate_api/config.py
+++ b/jobbergate-api/jobbergate_api/config.py
@@ -82,6 +82,8 @@ class Settings(BaseSettings):
     # Sentry configuration
     SENTRY_DSN: Optional[HttpUrl]
     SENTRY_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
+    SENTRY_PROFILING_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
+    SENTRY_TRACING_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
 
     # Maximum number of bytes allowed for file uploads
     MAX_UPLOAD_FILE_SIZE: int = 100 * 1024 * 1024  # 100 MB

--- a/jobbergate-api/jobbergate_api/main.py
+++ b/jobbergate-api/jobbergate_api/main.py
@@ -2,7 +2,6 @@
 Main file to startup the fastapi server.
 """
 import sys
-import typing
 from contextlib import asynccontextmanager
 
 import asyncpg
@@ -47,8 +46,10 @@ if settings.SENTRY_DSN and settings.DEPLOY_ENV.lower() != "test":
     logger.info("Initializing Sentry")
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
-        sample_rate=typing.cast(float, settings.SENTRY_SAMPLE_RATE),  # The cast silences mypy
+        sample_rate=settings.SENTRY_SAMPLE_RATE,
         environment=settings.DEPLOY_ENV,
+        profiles_sample_rate=settings.SENTRY_PROFILING_SAMPLE_RATE,
+        traces_sample_rate=settings.SENTRY_TRACING_SAMPLE_RATE,
     )
     subapp.add_middleware(SentryAsgiMiddleware)
 else:

--- a/jobbergate-api/jobbergate_api/storage.py
+++ b/jobbergate-api/jobbergate_api/storage.py
@@ -128,6 +128,7 @@ class SecureSession:
 def secure_session(
     *scopes: str,
     permission_mode: PermissionMode = PermissionMode.ALL,
+    commit: bool = True,
     ensure_email: bool = False,
     ensure_organization: bool = False,
     ensure_client_id: bool = False,
@@ -171,7 +172,7 @@ def secure_session(
             if is_test:
                 logger.debug("Committing nested transaction due to test mode")
                 await nested_transaction.commit()
-            else:
+            elif commit is True:
                 logger.debug("Committing session")
                 await session.commit()
         except Exception as err:


### PR DESCRIPTION
#### What
This PR applies a simple patch in the API code to avoid running `session.commit()` against the database while only read queries are run.

Porting changes from https://github.com/omnivector-solutions/license-manager/pull/284

#### Why
Enhance and track performance.


---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
