### PR TITLE
Fix status badge on README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
    <p align="center">
      <img
-       src="https://img.shields.io/github/workflow/status/omnivector-solutions/jobbergate/Test/main?label=main-build&logo=github&style=plastic"
+       src="https://img.shields.io/github/actions/workflow/status/omnivector-solutions/jobbergate/test_on_push.yaml?branch=main&label=main-build&logo=github&style=plastic"
        alt="main build"
      />
      <img


### PR DESCRIPTION
#### What
Fix the status badge on the README file

#### Why
Change to GitHub workflow badge routes: https://github.com/badges/shields/issues/8671

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
