### PR TITLE
ci: add timeout when testing the API

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -34,6 +34,7 @@ jobs:
   api-tests:
     name: "jobbergate-api tests"
     runs-on: "ubuntu-20.04"
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - name: Run QA


### PR DESCRIPTION
#### What
Make API's test raise timeout if running for more than 10 minutes.

#### Why
The tests are getting stuck every now and then, and GitHub will only cancel their execution after 6 hours.

This is a hotfix to make them fail early while we investigate the source of the issue. That is planned to be cover on https://app.clickup.com/t/18022949/PENG-1787

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
