### PR TITLE
[release/4.0] ci: add timeout when testing the API

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -34,6 +34,7 @@ jobs:
   api-tests:
     name: "jobbergate-api tests"
     runs-on: "ubuntu-20.04"
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - name: Run QA


### PR DESCRIPTION
Backport 38cbbfbc7a208647c9c0eafd2b663000948383ab from #384.