### PR TITLE
[ASP-4070] Distinguish application-id, job-script-id and job-submission-id

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,7 +4,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 - Added --cluster-name, --execution-directory and --download parameters to create-job-script command on submit mode
-- Change application-id, job-script-id and job-submission-id to havbe alias when displaying the id on the CLI
+- Change application-id, job-script-id and job-submission-id to have alias when displaying the id on the CLI
 
 
 ## 4.1.0a2 -- 2023-10-10

--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,6 +4,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 - Added --cluster-name, --execution-directory and --download parameters to create-job-script command on submit mode
+- Change application-id, job-script-id and job-submission-id to havbe alias when displaying the id on the CLI
 
 
 ## 4.1.0a2 -- 2023-10-10

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -127,7 +127,7 @@ class ApplicationResponse(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     Describes the format of data for applications retrieved from the Jobbergate API endpoints.
     """
 
-    id: int
+    application_id: int = pydantic.Field(alias="id")
     name: str
     owner_email: str
     created_at: datetime
@@ -165,7 +165,7 @@ class JobScriptResponse(
     Describes the format of data for job_scripts retrieved from the Jobbergate API endpoints.
     """
 
-    id: int
+    job_script_id: int = pydantic.Field(alias="id")
     application_id: Optional[int] = pydantic.Field(None, alias="parent_template_id")
     name: str
     description: Optional[str] = None
@@ -190,7 +190,7 @@ class JobSubmissionResponse(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     Describes the format of data for job_submissions retrieved from the Jobbergate API endpoints.
     """
 
-    id: int
+    job_submission_id: int = pydantic.Field(alias="id")
     job_script_id: int
     cluster_name: Optional[str] = pydantic.Field(alias="client_id")
     slurm_job_id: Optional[int]

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -160,7 +160,7 @@ def create(
         ),
     )
 
-    upload_job_script_files(jg_ctx, job_script_result.id, job_script_path, supporting_file_path)
+    upload_job_script_files(jg_ctx, job_script_result.job_script_id, job_script_path, supporting_file_path)
 
     render_single_result(
         jg_ctx,
@@ -299,7 +299,7 @@ def render(
     )
 
     if download:
-        download_job_script_files(job_script_result.id, jg_ctx)
+        download_job_script_files(job_script_result.job_script_id, jg_ctx)
 
     if not submit:
         return
@@ -322,7 +322,7 @@ def render(
     try:
         job_submission_result = create_job_submission(
             jg_ctx,
-            job_script_result.id,
+            job_script_result.job_script_id,
             job_script_result.name,
             job_script_result.description,
             cluster_name,

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -334,7 +334,9 @@ def render(
             "Failed to immediately submit the job after job script creation.",
             subject="Automatic job submission failed",
             support=True,
-            log_message=f"There was an issue submitting the job immediately job_script_id={job_script_result.id}.",
+            log_message=f"""
+                There was an issue submitting the job immediately job_script_id={job_script_result.job_script_id}.
+            """,
             original_error=err,
         )
 

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
@@ -201,7 +201,7 @@ def render_job_script(
 
     if not app_data.workflow_files:
         raise Abort(
-            f"Application {app_data.id} does not have a workflow file",
+            f"Application {app_data.application_id} does not have a workflow file",
             subject="Workflow file not found",
             log_message="Application does not have a workflow file",
         )
@@ -249,7 +249,7 @@ def render_job_script(
         JobScriptResponse,
         make_request(
             jg_ctx.client,
-            f"/jobbergate/job-scripts/render-from-template/{app_data.id}",
+            f"/jobbergate/job-scripts/render-from-template/{app_data.application_id}",
             "POST",
             expected_status=201,
             abort_message="Couldn't create job script",
@@ -268,7 +268,7 @@ def update_template_files_information(app_data: ApplicationResponse, app_config:
         list_of_entrypoints = [i.filename for i in app_data.template_files if i.file_type.upper() == "ENTRYPOINT"]
         if len(list_of_entrypoints) != 1:
             raise Abort(
-                f"Application {app_data.id} does not have one entry point, found {len(list_of_entrypoints)}",
+                f"Application {app_data.application_id} does not have one entry point, found {len(list_of_entrypoints)}",
                 subject="Entry point is unspecified",
                 log_message="Entry point file not specified",
             )

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
@@ -268,7 +268,9 @@ def update_template_files_information(app_data: ApplicationResponse, app_config:
         list_of_entrypoints = [i.filename for i in app_data.template_files if i.file_type.upper() == "ENTRYPOINT"]
         if len(list_of_entrypoints) != 1:
             raise Abort(
-                f"Application {app_data.application_id} does not have one entry point, found {len(list_of_entrypoints)}",
+                f"""
+                Application {app_data.application_id} does not have one entry point, found {len(list_of_entrypoints)}",
+                """,
                 subject="Entry point is unspecified",
                 log_message="Entry point file not specified",
             )

--- a/jobbergate-cli/tests/subapps/job_scripts/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_app.py
@@ -235,7 +235,7 @@ def test_render__non_fast_mode_and_job_submission(
     job_submission_data = dummy_job_submission_data[0]
 
     render_route = respx_mock.post(
-        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.id}"
+        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.application_id}"
     )
     render_route.mock(
         return_value=httpx.Response(
@@ -286,7 +286,7 @@ def test_render__non_fast_mode_and_job_submission(
             unwrap(
                 f"""
                 render {name_flag}{separator}dummy-name
-                       {application_id_flag}{separator}{application_response.id}
+                       {application_id_flag}{separator}{application_response.application_id}
                        --param-file={param_file_path}
                        {sbatch_params}
                 """
@@ -298,7 +298,7 @@ def test_render__non_fast_mode_and_job_submission(
     assert result.exit_code == 0, f"render failed: {result.stdout}"
     assert mocked_fetch_application_data.called_once_with(
         dummy_context,
-        id=application_response.id,
+        id=application_response.application_id,
         identifier=None,
     )
     assert mocked_create_job_submission.called_once_with(
@@ -365,7 +365,7 @@ def test_render__with_fast_mode_and_no_job_submission(
     job_script_data = dummy_job_script_data[0]
 
     render_route = respx_mock.post(
-        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.id}"
+        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.application_id}"
     )
     render_route.mock(
         return_value=httpx.Response(
@@ -409,7 +409,7 @@ def test_render__with_fast_mode_and_no_job_submission(
             unwrap(
                 f"""
                 render --name=dummy-name
-                       --application-id={application_response.id}
+                       --application-id={application_response.application_id}
                        --param-file={param_file_path}
                        --fast
                        --no-submit
@@ -422,7 +422,7 @@ def test_render__with_fast_mode_and_no_job_submission(
     assert result.exit_code == 0, f"render failed: {result.stdout}"
     assert mocked_fetch_application_data.called_once_with(
         dummy_context,
-        id=application_response.id,
+        id=application_response.application_id,
         identifier=None,
     )
     assert render_route.called
@@ -474,7 +474,7 @@ def test_render__submit_is_none_and_cluster_name_is_defined(
     job_script_data = dummy_job_script_data[0]
 
     render_route = respx_mock.post(
-        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.id}"
+        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.application_id}"
     )
     render_route.mock(
         return_value=httpx.Response(
@@ -508,7 +508,7 @@ def test_render__submit_is_none_and_cluster_name_is_defined(
             unwrap(
                 f"""
                 render --name=dummy-name
-                       --application-id={application_response.id}
+                       --application-id={application_response.application_id}
                        --param-file={param_file_path}
                        --cluster-name=dummy-cluster
                        {sbatch_params}

--- a/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
@@ -106,7 +106,7 @@ def test_render_job_script__providing_a_name(
         new=dummy_render_class,
     )
     create_route = respx_mock.post(
-        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.id}"
+        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.application_id}"
     )
     create_route.mock(
         return_value=httpx.Response(
@@ -178,7 +178,7 @@ def test_render_job_script__without_a_name(
         new=dummy_render_class,
     )
     create_route = respx_mock.post(
-        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.id}"
+        f"{dummy_domain}/jobbergate/job-scripts/render-from-template/{application_response.application_id}"
     )
     create_route.mock(
         return_value=httpx.Response(
@@ -190,13 +190,13 @@ def test_render_job_script__without_a_name(
     actual_job_script_data = render_job_script(
         dummy_context,
         name=None,
-        application_id=application_response.id,
+        application_id=application_response.application_id,
         fast=True,
     )
 
     mocked_fetch_application_data.assert_called_once_with(
         dummy_context,
-        id=application_response.id,
+        id=application_response.application_id,
         identifier=None,
     )
 

--- a/jobbergate-cli/tests/subapps/job_submissions/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_app.py
@@ -30,7 +30,7 @@ def test_create(
     job_submission_data = JobSubmissionResponse(**dummy_job_submission_data[0])
     job_submission_name = job_submission_data.name
     job_submission_description = job_submission_data.description
-    job_script_id = job_submission_data.id
+    job_script_id = job_submission_data.job_script_id
 
     param_file_path = tmp_path / "param_file.json"
     param_file_path.write_text(json.dumps(job_submission_data.execution_parameters))


### PR DESCRIPTION
#### What
Add alias to `application-id`, `job-script-id` and `job-submission-id` to distinguish each other when submitting a job.

#### Why
All of them were displayed as `id`, which was confusing the users.

`Task`: https://jira.scania.com/browse/ASP-4070

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
