### PR TITLE
[ASP-4069] Naming convention for job files

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 
+- Added a new config to change the way job-script files are named to `<job-script-name>.job`, following behavior from jobbergate-legacy
+
 ## 4.1.0 -- 2023-11-07
 
 - Added ability to open the login url on browser or copy it to clipboard

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -55,6 +55,7 @@ class Settings(BaseSettings):
 
     # Compatibility mode: If True, add commands as they appear in the legacy app
     JOBBERGATE_COMPATIBILITY_MODE: Optional[bool] = False
+    JOBBERGATE_LEGACY_NAME_CONVENTION: Optional[bool] = False
 
     # Auth0 config for machine-to-machine security
     OIDC_DOMAIN: str

--- a/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
@@ -360,7 +360,19 @@ class TestGetTemplateOutputNameMapping:
         )
         expected_mapping = {"template.j2": "template"}
 
-        assert get_template_output_name_mapping(config) == expected_mapping
+        assert get_template_output_name_mapping(config, "dummy-name") == expected_mapping
+
+    def test_default_template_valid_output_name__legacy_mode(self, tweak_settings):
+        config = JobbergateConfig(
+            default_template="templates/template.j2",
+            output_directory=pathlib.Path("."),
+            supporting_files=None,
+            supporting_files_output_name=None,
+        )
+        expected_mapping = {"template.j2": "dummy-name.job"}
+
+        with tweak_settings(JOBBERGATE_LEGACY_NAME_CONVENTION=True):
+            assert get_template_output_name_mapping(config, "dummy-name") == expected_mapping
 
     def test_supporting_files_with_valid_output_names(self):
         config = JobbergateConfig(
@@ -376,7 +388,7 @@ class TestGetTemplateOutputNameMapping:
 
         expected_mapping = {"template1.j2": "template1", "support1.j2": "output1.txt", "support2.j2": "output2.txt"}
 
-        assert get_template_output_name_mapping(config) == expected_mapping
+        assert get_template_output_name_mapping(config, "dummy-name") == expected_mapping
 
     def test_default_template_not_specified(self):
         config = JobbergateConfig(
@@ -386,7 +398,7 @@ class TestGetTemplateOutputNameMapping:
             supporting_files=None,
         )
         with pytest.raises(Abort, match="Default template was not specified"):
-            get_template_output_name_mapping(config)
+            get_template_output_name_mapping(config, "dummy-name")
 
     def test_supporting_files_output_names_multiple_values(self):
         config = JobbergateConfig(
@@ -397,7 +409,7 @@ class TestGetTemplateOutputNameMapping:
         )
 
         with pytest.raises(Abort, match="template='template2.j2' has 2 output names"):
-            get_template_output_name_mapping(config)
+            get_template_output_name_mapping(config, "dummy-name")
 
 
 class TestUploadJobScriptFiles:


### PR DESCRIPTION
#### What
Make it behave like in legacy jobbergate.

#### Why
The modification and interpretation of .job-files is a daily part of the job for simulation engineers. For some physical problems adjustment of the .job-file is an iterative process, for all physical problems it's part of the bug finding if something goes wrong in the analysis. Therefore a lot of time can be saved by keeping track of what .job-file corresponds to what SLURM job.

`Task`: https://jira.scania.com/browse/ASP-4069

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
