### PR TITLE
[ASP-3985] Remove questions for cluster name and execution dir on submit mode

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -5,6 +5,7 @@ This file keeps track of all notable changes to jobbergate-cli
 ## Unreleased
 
 - Added ability to open the login url on browser or copy it to clipboard
+- Removed the questions for cluster name and execution directory on submit mode
 
 ## 4.1.0a3 -- 2023-11-03
 

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, cast
 
 import typer
 
-from jobbergate_cli.config import settings
 from jobbergate_cli.constants import SortOrder
 from jobbergate_cli.exceptions import Abort, handle_abort
 from jobbergate_cli.render import StyleMapper, render_list_results, render_single_result, terminal_message
@@ -303,21 +302,6 @@ def render(
 
     if not submit:
         return
-
-    cluster_name = question_helper(
-        question_func=typer.prompt,
-        text="What cluster should this job be submitted to?",
-        default=settings.DEFAULT_CLUSTER_NAME,
-        fast=fast,
-        actual_value=cluster_name,
-    )
-    execution_directory = question_helper(
-        question_func=typer.prompt,
-        text="Where should this job be executed?",
-        default=pathlib.Path.cwd(),
-        fast=fast,
-        actual_value=execution_directory,
-    )
 
     try:
         job_submission_result = create_job_submission(


### PR DESCRIPTION
#### What
Remove the questions regarding the cluster and execution dir when creating a job script on submit mode.

#### Why
The question was confusing the users.
Since there's the option to specify the values as parameters in the code, the best course of action was to remove the questions and use the default values when not provided.

`Task`: https://jira.scania.com/browse/ASP-3985

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
