### PR TITLE
[ASP-3985] Patch create-job-script on --submit mode

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,8 +4,10 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 
+- Patched create-job-script command on submit mode when parameter file is provided
 
 ## 4.2.0a0 -- 2023-11-09
+
 - Added a new config to change the way job-script files are named to `<job-script-name>.job`, following behavior from jobbergate-legacy
 
 ## 4.1.0 -- 2023-11-07

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -305,13 +305,13 @@ def render(
 
     try:
         job_submission_result = create_job_submission(
-            jg_ctx,
-            job_script_result.job_script_id,
-            job_script_result.name,
-            job_script_result.description,
-            cluster_name,
-            execution_directory,
-            param_file,
+            jg_ctx=jg_ctx,
+            job_script_id=job_script_result.job_script_id,
+            name=job_script_result.name,
+            description=job_script_result.description,
+            cluster_name=cluster_name,
+            execution_directory=execution_directory,
+            execution_parameters_file=None,
         )
     except Exception as err:
         raise Abort(


### PR DESCRIPTION
#### What
Patch `create-job-script`

#### Why
param_file should not be provided to create_job_submission
since they have different functionalities

`Task`: https://jira.scania.com/browse/ASP-3985

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
