### PR TITLE
PENG-1910 Fixed recurring failures in CI pipeline

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -3,6 +3,8 @@
 This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
+- Moved database session management into a dedicated context manager and removed test-aware logic
+- Modified testing harnesses to override session management context manager and fail if test session is not used
 
 
 ## 4.2.0a1 -- 2023-11-13

--- a/jobbergate-api/jobbergate_api/storage.py
+++ b/jobbergate-api/jobbergate_api/storage.py
@@ -137,7 +137,6 @@ class EngineFactory:
             await session.close()
 
 
-
 engine_factory = EngineFactory()
 
 

--- a/jobbergate-api/tests/apps/job_script_templates/test_routers.py
+++ b/jobbergate-api/tests/apps/job_script_templates/test_routers.py
@@ -15,32 +15,6 @@ from jobbergate_api.apps.services import ServiceError
 pytest.mark.usefixtures("synth_session")
 
 
-async def test_create_job_template__async(
-    client,
-    fill_job_template_data,
-    inject_security_header,
-):
-    """Test the API can accept concurrent requests."""
-
-    async def submit():
-        payload = fill_job_template_data(
-            name="Test Template",
-            description="This is a test template",
-            template_vars=dict(foo="bar"),
-        )
-
-        tester_email = payload.pop("owner_email")
-        inject_security_header(tester_email, Permissions.JOB_TEMPLATES_EDIT)
-
-        return await client.post("jobbergate/job-script-templates", json=payload)
-
-    to_do = [submit() for _ in range(4)]
-    responses = await asyncio.gather(*to_do)
-    for i, response in enumerate(responses):
-        logger.info(f"Response {i}: {response.status_code}")
-        response.raise_for_status()
-
-
 async def test_create_job_template__success(
     client,
     fill_job_template_data,
@@ -174,6 +148,7 @@ async def test_update_job_template__fail_not_found(
     client,
     tester_email,
     inject_security_header,
+    synth_session,
 ):
     job_template_id = 0
     payload = dict(
@@ -282,6 +257,7 @@ async def test_delete_job_template__fail_not_found(
     client,
     tester_email,
     inject_security_header,
+    synth_session,
 ):
     job_template_id = 0
     inject_security_header(tester_email, Permissions.JOB_TEMPLATES_EDIT)

--- a/jobbergate-api/tests/apps/job_script_templates/test_services.py
+++ b/jobbergate-api/tests/apps/job_script_templates/test_services.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import inspect
+
 from jobbergate_api.apps.constants import FileType
 from jobbergate_api.apps.job_script_templates.constants import WORKFLOW_FILE_NAME
 
@@ -21,7 +22,6 @@ def template_test_data() -> dict[str, Any]:
 
 
 class TestJobScriptTemplateCrudService:
-
     @pytest.mark.parametrize("locator_attribute", ("id", "identifier"))
     async def test_get__success(self, locator_attribute, template_test_data, synth_services):
         """Test that the template is recovered successfully using multiple locator attributes."""

--- a/jobbergate-api/tests/apps/job_scripts/test_routers.py
+++ b/jobbergate-api/tests/apps/job_scripts/test_routers.py
@@ -277,6 +277,7 @@ async def test_render_job_script_from_template__without_template(
     client,
     inject_security_header,
     tester_email,
+    synth_session,
 ):
     """
     Test POST /job_scripts/render-from-template can't create a job_script if the template file is unavailable.
@@ -334,6 +335,7 @@ async def test_get_job_script_by_id__invalid_id(
     client,
     inject_security_header,
     tester_email,
+    synth_session,
 ):
     """
     Test the correct response code is returned when a job_script does not exist.
@@ -740,7 +742,7 @@ class TestJobScriptFiles:
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-async def test_auto_clean_unused_entries(client, tester_email, inject_security_header):
+async def test_auto_clean_unused_entries(client, tester_email, inject_security_header, synth_session):
     """Test that unused job scripts are automatically cleaned."""
     inject_security_header(tester_email, Permissions.JOB_SCRIPTS_EDIT)
     response = await client.delete("jobbergate/job-scripts/clean-unused-entries")

--- a/jobbergate-api/tests/apps/job_scripts/test_routers.py
+++ b/jobbergate-api/tests/apps/job_scripts/test_routers.py
@@ -2,6 +2,7 @@
 import pytest
 from fastapi import HTTPException, status
 from loguru import logger
+
 from jobbergate_api.apps.permissions import Permissions
 
 # Not using the synth_session fixture in a route that needs the database is unsafe
@@ -666,7 +667,7 @@ class TestJobScriptFiles:
         inject_security_header,
         job_script_data,
         job_script_data_as_string,
-        synth_services
+        synth_services,
     ):
         id = job_script_data.id
         file_type = "ENTRYPOINT"

--- a/jobbergate-api/tests/apps/job_scripts/test_services.py
+++ b/jobbergate-api/tests/apps/job_scripts/test_services.py
@@ -23,7 +23,9 @@ def script_test_data() -> dict[str, Any]:
 
 class TestIntegration:
     @pytest.mark.parametrize("file_type", [FileType.ENTRYPOINT, FileType.ENTRYPOINT.value])
-    async def test_file_upsert__guarantee_only_one_entrypoint(self, file_type, script_test_data, synth_services):
+    async def test_file_upsert__guarantee_only_one_entrypoint(
+        self, file_type, script_test_data, synth_services
+    ):
         """
         Ensure that only one entrypoint file is allowed.
         """
@@ -142,7 +144,9 @@ class TestIntegration:
             await synth_services.file.job_script.get(script_file.parent_id, script_file.filename)
         assert exc_info.value.status_code == 404
 
-    async def test_delete_updates_related_submissions(self, script_test_data, fill_job_script_data, synth_services):
+    async def test_delete_updates_related_submissions(
+        self, script_test_data, fill_job_script_data, synth_services
+    ):
         """
         Test all related submissions still on status CREATED are updated when parent job-script is deleted.
         """
@@ -171,7 +175,9 @@ class TestIntegration:
             await synth_services.crud.job_script.get(target_for_deletion.id)
         assert exc_info.value.status_code == 404
 
-        actual_submissions = await synth_services.crud.job_submission.list(sort_field="id", sort_ascending=True)
+        actual_submissions = await synth_services.crud.job_submission.list(
+            sort_field="id", sort_ascending=True
+        )
 
         assert [s.status for s in actual_submissions] == [s.get("status") for s in expected_submissions]
 

--- a/jobbergate-api/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/tests/apps/job_submissions/test_routers.py
@@ -310,6 +310,7 @@ async def test_create_job_submission_without_job_script(
     client,
     fill_job_submission_data,
     inject_security_header,
+    synth_session,
 ):
     """
     Test that is not possible to create a job_submission without a job_script.
@@ -437,7 +438,7 @@ async def test_get_job_submission_by_id_bad_permission(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-async def test_get_job_submission_by_id_invalid(client, inject_security_header):
+async def test_get_job_submission_by_id_invalid(client, inject_security_header, synth_session):
     """
     Test the correct response code is returned when a job_submission does not exist.
 
@@ -973,6 +974,7 @@ async def test_get_job_submissions_applies_no_slurm_filter_if_slurm_job_ids_is_e
 async def test_get_job_submissions_with_invalid_slurm_job_ids_param(
     client,
     inject_security_header,
+    synth_session,
 ):
     """
     Test GET /job-submissions/ returns a 422 if the slurm_job_id parameter is invalid.
@@ -1150,7 +1152,7 @@ async def test_delete_job_submission(
     await synth_services.crud.job_submission.count() == 0
 
 
-async def test_delete_job_submission_not_found(client, inject_security_header):
+async def test_delete_job_submission_not_found(client, inject_security_header, synth_session):
     """
     Test that it is not possible to delete a job_submission that is not found.
 

--- a/jobbergate-api/tests/apps/job_submissions/test_services.py
+++ b/jobbergate-api/tests/apps/job_submissions/test_services.py
@@ -1,11 +1,14 @@
 """Database models for the job scripts resource."""
 
 from sqlalchemy import inspect
+
 from jobbergate_api.apps.constants import FileType
 
 
 class TestIntegration:
-    async def test_get_includes_all_files(self, fill_job_script_data, fill_job_submission_data, synth_services):
+    async def test_get_includes_all_files(
+        self, fill_job_script_data, fill_job_submission_data, synth_services
+    ):
         script_instance = await synth_services.crud.job_script.create(**fill_job_script_data())
         submission_instance = await synth_services.crud.job_submission.create(
             **fill_job_submission_data(), job_script_id=script_instance.id
@@ -37,7 +40,9 @@ class TestIntegration:
 
         assert result.job_script == script_instance
 
-    async def test_get_not_include_parent(self, fill_job_script_data, fill_job_submission_data, synth_services):
+    async def test_get_not_include_parent(
+        self, fill_job_script_data, fill_job_submission_data, synth_services
+    ):
         script_instance = await synth_services.crud.job_script.create(**fill_job_script_data())
         submission_instance = await synth_services.crud.job_submission.create(
             **fill_job_submission_data(), job_script_id=script_instance.id
@@ -47,7 +52,9 @@ class TestIntegration:
 
         assert "job_script" in inspect(result).unloaded
 
-    async def test_list_includes_all_files(self, fill_job_script_data, fill_job_submission_data, synth_services):
+    async def test_list_includes_all_files(
+        self, fill_job_script_data, fill_job_submission_data, synth_services
+    ):
         script_instance = await synth_services.crud.job_script.create(**fill_job_script_data())
         submission_instance = await synth_services.crud.job_submission.create(
             **fill_job_submission_data(), job_script_id=script_instance.id
@@ -64,7 +71,9 @@ class TestIntegration:
         assert actual_result == [submission_instance]
         assert actual_result[0].job_script.files == [script_file]
 
-    async def test_update_includes_no_files(self, fill_job_script_data, fill_job_submission_data, synth_services):
+    async def test_update_includes_no_files(
+        self, fill_job_script_data, fill_job_submission_data, synth_services
+    ):
         script_instance = await synth_services.crud.job_script.create(**fill_job_script_data())
         submission_instance = await synth_services.crud.job_submission.create(
             **fill_job_submission_data(), job_script_id=script_instance.id

--- a/jobbergate-api/tests/conftest.py
+++ b/jobbergate-api/tests/conftest.py
@@ -15,11 +15,11 @@ from fastapi import status
 from httpx import AsyncClient, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from jobbergate_api.apps.dependencies import get_bucket_name, get_bucket_url, s3_bucket, service_factory
 from jobbergate_api.apps.models import Base
 from jobbergate_api.config import settings
 from jobbergate_api.main import app
 from jobbergate_api.storage import engine_factory
-from jobbergate_api.apps.dependencies import s3_bucket, get_bucket_name, get_bucket_url, service_factory
 
 # Charset for producing random strings
 CHARSET = string.ascii_letters + string.digits + string.punctuation
@@ -120,6 +120,7 @@ async def synth_bucket(synth_s3_bucket_session):
     finally:
         await synth_s3_bucket_session.objects.all().delete()
 
+
 @pytest.fixture(scope="function")
 async def synth_services(synth_session, synth_bucket):
     """
@@ -127,6 +128,7 @@ async def synth_services(synth_session, synth_bucket):
     """
     with service_factory(synth_session, synth_bucket) as services:
         yield services
+
 
 @pytest.fixture(autouse=True)
 def enforce_mocked_oidc_provider(mock_openid_server):

--- a/jobbergate-api/tests/test_security.py
+++ b/jobbergate-api/tests/test_security.py
@@ -2,14 +2,16 @@
 Test the security module.
 """
 from unittest.mock import patch
+
 import pytest
+
 from jobbergate_api.security import (
+    HTTPException,
     IdentityPayload,
     TokenPayload,
-    lockdown_with_identity,
-    HTTPException,
-    settings,
     get_domain_configs,
+    lockdown_with_identity,
+    settings,
 )
 
 
@@ -108,7 +110,7 @@ def test_lockdown_with_identity_ensure_fields__raises_error(opt_name):
 def test_lockdown_with_identity__backward_compatibility():
     """
     Check if the lockdown_with_identity decorator returns the correct identity.
-    
+
     For backwards compatibility, the organization_id is set to None if it is a string.
     """
     token_raw_data = dict(


### PR DESCRIPTION
I moved the session management code in the storage module into its own context manager. Then, I modified the conftest to override this particular part of the code only. Now, the storage code is minimally aware of special test logic (it only blows up if the session context manager is used in a test) and the particulars of managing a session for a test are isolated in the conftest.py

I also eliminated the async specific tests. Because the test fixtures force routes to use a preset session, you can't call multiple routes simultaneously due to this sqlalchemy error: https://docs.sqlalchemy.org/en/20/errors.html#error-isce. Any validation of concurrency should occur as part of an integration test instead.
