### PR TITLE
Patch intermittent test errors on pagination

### DIFF
--- a/jobbergate-api/tests/apps/job_script_templates/test_routers.py
+++ b/jobbergate-api/tests/apps/job_script_templates/test_routers.py
@@ -341,7 +341,7 @@ class TestListJobTemplates:
         inject_security_header(tester_email, Permissions.JOB_TEMPLATES_VIEW)
         response = await client.get(
             "jobbergate/job-script-templates",
-            params=dict(include_null_identifier=True, include_archived=True),
+            params=dict(include_null_identifier=True, include_archived=True, sort_field="id"),
         )
         assert response.status_code == 200, f"List failed: {response.text}"
 

--- a/jobbergate-api/tests/apps/job_scripts/test_routers.py
+++ b/jobbergate-api/tests/apps/job_scripts/test_routers.py
@@ -416,7 +416,7 @@ class TestListJobScripts:
         job_scripts_list,
     ):
         inject_security_header(tester_email, Permissions.JOB_SCRIPTS_VIEW)
-        response = await client.get("jobbergate/job-scripts?include_archived=True")
+        response = await client.get("jobbergate/job-scripts?include_archived=True&sort_field=id")
         assert response.status_code == 200, f"Get failed: {response.text}"
 
         response_data = response.json()


### PR DESCRIPTION
#### What
Patch pagination tests by enforcing the response is ordered by id.

#### Why
The unsorted response was producing intermittent errors, for instance: https://github.com/omnivector-solutions/jobbergate/actions/runs/6937478812/job/18871607426

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
