### PR TITLE
[ASP-4245] Update agent download logic file

### DIFF
--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to jobbergate-core
 
 ## Unreleased
-- Added env var to control whether the job script files should be downloaded or not
+- Added setting to specify if the job script files should be written to the submit directory
 
 ## 4.2.0a1 -- 2023-11-13
 - Added setting to control the timeout on `httpx` requests

--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to jobbergate-core
 
 ## Unreleased
-
+- Added env var to control whether the job script files should be downloaded or not
 
 ## 4.2.0a1 -- 2023-11-13
 - Added setting to control the timeout on `httpx` requests

--- a/jobbergate-agent/jobbergate_agent/settings.py
+++ b/jobbergate-agent/jobbergate_agent/settings.py
@@ -51,7 +51,7 @@ class Settings(BaseSettings):
     TASK_GARBAGE_COLLECTION_HOUR: Optional[int] = Field(None, ge=0, le=23)  # hour of day
 
     # Job submission settings
-    DOWNLOAD_JOB_SCRIPTS: bool = True
+    WRITE_SUBMISSION_FILES: bool = True
 
     @root_validator
     def compute_extra_settings(cls, values):

--- a/jobbergate-agent/jobbergate_agent/settings.py
+++ b/jobbergate-agent/jobbergate_agent/settings.py
@@ -50,6 +50,9 @@ class Settings(BaseSettings):
     TASK_JOBS_INTERVAL_SECONDS: int = Field(60, ge=10, le=3600)  # seconds
     TASK_GARBAGE_COLLECTION_HOUR: Optional[int] = Field(None, ge=0, le=23)  # hour of day
 
+    # Job submission settings
+    DOWNLOAD_JOB_SCRIPTS: bool = True
+
     @root_validator
     def compute_extra_settings(cls, values):
         """

--- a/jobbergate-agent/tests/jobbergate/conftest.py
+++ b/jobbergate-agent/tests/jobbergate/conftest.py
@@ -26,11 +26,33 @@ def dummy_template_source():
 
 @pytest.fixture
 def dummy_job_script_files():
+    """
+    Provide a fixture that returns a list of dummy job script files.
+    """
     return [
         {
             "parent_id": 1,
             "filename": "application.sh",
             "file_type": "ENTRYPOINT",
+        },
+    ]
+
+
+@pytest.fixture
+def dummy_job_script_with_supporting_files():
+    """
+    Provide a fixture that returns a list of dummy job script files with supporting files.
+    """
+    return [
+        {
+            "parent_id": 1,
+            "filename": "application.sh",
+            "file_type": "ENTRYPOINT",
+        },
+        {
+            "parent_id": 1,
+            "filename": "input.txt",
+            "file_type": "SUPPORT",
         },
     ]
 
@@ -45,5 +67,19 @@ def dummy_pending_job_submission_data(dummy_job_script_files, tmp_path):
         name="sub1",
         owner_email="email1@dummy.com",
         job_script={"files": dummy_job_script_files},
+        slurm_job_id=13,
+    )
+
+
+@pytest.fixture
+def dummy_pending_job_submission_with_supporting_files_data(dummy_job_script_with_supporting_files, tmp_path):
+    """
+    Provide a fixture that returns a dict that is compatible with PendingJobSubmission and has supporting files.
+    """
+    return dict(
+        id=1,
+        name="sub1",
+        owner_email="email1.@dummy.com",
+        job_script={"files": dummy_job_script_with_supporting_files},
         slurm_job_id=13,
     )


### PR DESCRIPTION
#### What
Add the env var `DOWNLOAD_JOB_SCRIPT` to control whether the agent should download the job script file.
If it's set to `True`, the behaviour is exactly as before.
If it's set to `False`, the submission will be rejected if there are supporting files. If there aren't, the job script will be passed to the `slurmrestd` API as the payload and won't be downloaded to the submit dir.

#### Why
The submission was failing when the agent didn't have permission to write to the submit dir.

`Task`: https://jira.scania.com/browse/ASP-4245

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
