### PR TITLE
[ASP-4238] Add on-site submission support

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -4,14 +4,17 @@ This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
 
+- Added support for on-site job submissions [ASP-4238]
 
 ## 4.2.0a2 -- 2023-11-29
+
 - Moved database session management into a dedicated context manager and removed test-aware logic
 - Modified testing harnesses to override session management context manager and fail if test session is not used
 
-
 ## 4.2.0a1 -- 2023-11-13
+
 ## 4.2.0a0 -- 2023-11-09
+
 ## 4.1.0 -- 2023-11-07
 
 - Changed internals to avoid committing to the database when a GET request is made
@@ -183,27 +186,30 @@ This file keeps track of all notable changes to jobbergate-api
 
 ## 2.1.2 -- 2022-02-02
 
-* Revised permissions to use a view/edit model for each data model
+- Revised permissions to use a view/edit model for each data model
+
 - Added parameter to filter job_submissions by slurm_job_id
 
 ## 2.1.1 -- 2022-01-13
 
-* Refactored the Dockerfile
+- Refactored the Dockerfile
 
 ## 2.1.0 -- 2021-12-22
 
-* Added graceful handling of delete failures due to FK constraints
+- Added graceful handling of delete failures due to FK constraints
+
 - Added Alembic support
 - Added application_identifier to response payload
 - Added pagination support back in
 
 ## 2.0.1 -- 2021-12-10
 
-* Removed CORS origins parameter from settings and set all origins as the allowed ones
+- Removed CORS origins parameter from settings and set all origins as the allowed ones
 
 ## 2.0.0 -- 2021-12-08
 
-* Added support for auth via Armasec & Auth0
+- Added support for auth via Armasec & Auth0
+
 - Added unit tests
 - Migrated model definitions from legacy `jobbergate-api`
 - Migrated endpoint definitions from legacy `jobbergate-api`

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -163,8 +163,7 @@ class JobProperties(BaseModel, extra=Extra.forbid):
             "'user' option or with the 'mcs' option)."
         )
     )
-    get_user_environment: int = Field(
-        default=1,
+    get_user_environment: Optional[int] = Field(
         description="Load new login environment for user on job node.",
         ge=0,
         le=1,
@@ -305,6 +304,7 @@ class JobSubmissionCreateRequest(BaseModel):
     name: str
     description: Optional[str]
     job_script_id: int
+    slurm_job_id: Optional[int]
     execution_directory: Optional[str]
     client_id: Optional[str]
     execution_parameters: JobProperties = Field(default_factory=JobProperties)

--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,9 +4,11 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 
+- Added support for on-site job submissions using the `sbatch` command [ASP-4238]
 
 ## 4.2.0a2 -- 2023-11-29
 ## 4.2.0a1 -- 2023-11-13
+
 - Patched create-job-script command on submit mode when parameter file is provided
 - Added setting to control the timeout on `httpx` requests
 

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -24,6 +24,8 @@ class Settings(BaseSettings):
 
     ARMADA_API_BASE: AnyHttpUrl = Field("https://armada-k8s.staging.omnivector.solutions")
 
+    SBATCH_PATH: Optional[Path]
+
     # enable http tracing
     JOBBERGATE_DEBUG: bool = Field(False)
     JOBBERGATE_REQUESTS_TIMEOUT: Optional[int] = 15

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -140,7 +140,7 @@ class ApplicationResponse(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     workflow_files: List[WorkflowFileResponse] = []
 
 
-class JobScriptFiles(pydantic.BaseModel, extra=pydantic.Extra.ignore):
+class JobScriptFile(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     """
     Model containing job-script files.
     """
@@ -173,7 +173,7 @@ class JobScriptResponse(
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    files: List[JobScriptFiles] = []
+    files: List[JobScriptFile] = []
 
     @pydantic.validator("files", pre=True)
     def null_files(cls, value):
@@ -239,6 +239,7 @@ class JobSubmissionCreateRequestData(pydantic.BaseModel):
     name: str
     description: Optional[str] = None
     job_script_id: int
+    slurm_job_id: Optional[int] = None
     client_id: Optional[str] = pydantic.Field(None, alias="cluster_name")
     execution_directory: Optional[Path] = None
     execution_parameters: Dict[str, Any] = pydantic.Field(default_factory=dict)

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -13,7 +13,6 @@ from jobbergate_cli.exceptions import handle_abort
 from jobbergate_cli.render import StyleMapper, render_list_results, render_single_result, terminal_message
 from jobbergate_cli.requests import make_request
 from jobbergate_cli.schemas import JobbergateContext, ListResponseEnvelope
-from jobbergate_cli.subapps.job_scripts.tools import download_job_script_files
 from jobbergate_cli.subapps.job_submissions.tools import create_job_submission, fetch_job_submission_data
 
 
@@ -100,10 +99,8 @@ def create(
         execution_directory=execution_directory,
         cluster_name=cluster_name,
         execution_parameters_file=execution_parameters,
+        download=download,
     )
-
-    if download:
-        download_job_script_files(job_script_id, jg_ctx)
 
     render_single_result(
         jg_ctx,

--- a/jobbergate-cli/tests/subapps/job_submissions/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_app.py
@@ -40,9 +40,6 @@ def test_create(
         "jobbergate_cli.subapps.job_submissions.app.create_job_submission",
     )
     patched_create_job_submission.return_value = job_submission_data
-    mocked_download_job_script = mocker.patch(
-        "jobbergate_cli.subapps.job_submissions.app.download_job_script_files",
-    )
 
     test_app = make_test_app("create", create)
     result = cli_runner.invoke(
@@ -67,7 +64,6 @@ def test_create(
         title="Created Job Submission",
         hidden_fields=HIDDEN_FIELDS,
     )
-    mocked_download_job_script.assert_called_once_with(job_script_id, dummy_context)
 
 
 def test_list_all__makes_request_and_renders_results(

--- a/jobbergate-docs/CHANGELOG.md
+++ b/jobbergate-docs/CHANGELOG.md
@@ -4,10 +4,14 @@ This file keeps track of all notable changes to jobbergate-docs
 
 ## Unreleased
 
+- Added new page describing the support for on-site job submissions [ASP-4238]
 
 ## 4.2.0a2 -- 2023-11-29
+
 ## 4.2.0a1 -- 2023-11-13
+
 ## 4.2.0a0 -- 2023-11-09
+
 ## 4.1.0 -- 2023-11-07
 
 - Converted to Markdown and built with mkdocs-material

--- a/jobbergate-docs/docs/source/elements/apps/cli.md
+++ b/jobbergate-docs/docs/source/elements/apps/cli.md
@@ -150,3 +150,21 @@ This means that some of the questions can be truncated and will not be fully vis
 !!!Note
 
     To ensure that you can see the full output of the CLI, we recommend that you use a terminal in a maximized window.
+
+## Submission Modes
+
+The Jobbergate CLI supports two modes for submitting jobs:
+
+- Remote Job Submission:
+
+    - `SBATCH_PATH` is configured on the CLI, so the payload to create a new submission does not include `slurm_job_id`.
+    - The API processes the creation as usual, giving it the status `CREATED` and adding the new entry on the database.
+    - The agent pulls pending jobs (`status=CREATED`) and submit them to slurm on every cycle using [Slurm Rest Api](https://slurm.schedmd.com/rest.html).
+    - The agent pulls active jobs (`STATUS=SUBMITTED`) and update their status on every cycle.
+
+- Aiming to provide backward compatibility with Jobbergate-cli v1, on-site submissions are also available (new in 4.2.0):
+
+    - `SBATCH_PATH` is configured on the CLI, so it downloads job-script files, submits them to slurm using `sbatch`, and includes `slurm_job_id` on the payload to create a new submissions.
+    - The API processes the creation giving it the status `SUBMITTED` and adding the new entry on the database. No need to parse any job-property, since all `#SBATCH` directives were processed at submission time by sbatch.
+    - This jobs won't be processed as pending by the agent since their status is not `CREATED`, remember it was already submitted.
+    - Just like on remote submissions, the agent will still keep track of active jobs (`STATUS=SUBMITTED`) and update them as needed.


### PR DESCRIPTION
#### What
- Add support for on-site submissions:
    - `SBATCH_PATH` is set on the CLI, so it is expected to download job-script files, submit them to slurm using `sbatch`, and include `slurm_job_id` on the payload to create a new submission.
    - The API processes the creation giving it the status `SUBMITTED` and adding the new entry on the database. No need to parse any job-property, since all `#SBATCH` directives were processed at submission time by sbatch.
    - These jobs won't be processed as pending by the agent since their status is not `CREATED`, remember it was already submitted.
    - Like on remote submissions, the agent will keep track of active jobs (`STATUS=SUBMITTED`) and update them as needed.

#### Why
As a Jobbergate maintainer, I want to add support for on-site submissions to the next-gen Jobbergate, so that it can operate with feature parity compared to the legacy system, thereby facilitating user-base migration. Meanwhile, current support for remote submissions will remain undisturbed.

`Task`: https://jira.scania.com/browse/ASP-4238

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
