### PR TITLE
[ASP-4053] Enhance user experience on jobbergate login

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,11 +4,14 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 
+- Fixed the setting `CACHE_DIR` to expand the user home directory, allowing more flexibility on the path [ASP-4053]
 
 ## 4.2.0a3 -- 2023-11-30
+
 - Added support for on-site job submissions using the `sbatch` command [ASP-4238]
 
 ## 4.2.0a2 -- 2023-11-29
+
 ## 4.2.0a1 -- 2023-11-13
 
 - Patched create-job-script command on submit mode when parameter file is provided

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -72,6 +72,7 @@ class Settings(BaseSettings):
         """
         Compute settings values that are based on other settings values.
         """
+        values["JOBBERGATE_CACHE_DIR"] = Path(values["JOBBERGATE_CACHE_DIR"]).expanduser().resolve()
         cache_dir = values["JOBBERGATE_CACHE_DIR"]
         cache_dir.mkdir(exist_ok=True, parents=True)
 

--- a/jobbergate-cli/tests/test_config.py
+++ b/jobbergate-cli/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pydantic
 import pytest
@@ -29,3 +30,9 @@ def test_Validation_error__when_parameter_is_missing():
     finally:
         if original_value is not None:
             os.environ["OIDC_DOMAIN"] = original_value
+
+
+def test_cache_dir__expands_user_and_resolves():
+    settings = Settings(JOBBERGATE_CACHE_DIR="~/.jobbergate-cli-prod")
+    assert settings.JOBBERGATE_CACHE_DIR == Path.home() / ".jobbergate-cli-prod"
+    assert settings.JOBBERGATE_CACHE_DIR.is_absolute()


### PR DESCRIPTION
#### What
Expand username on the path for `cache_dir`.

#### Why
In this way, we can set a different cache directory for each environment (QA, staging, prod) the user has access to, avoiding conflicts on access credentials.

`Task`: https://jira.scania.com/browse/ASP-4053

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
