### PR TITLE
[ASP-4228] Avoid name conflicts on BooleanList

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -5,6 +5,7 @@ This file keeps track of all notable changes to jobbergate-cli
 ## Unreleased
 
 - Fixed the setting `CACHE_DIR` to expand the user home directory, allowing more flexibility on the path [ASP-4053]
+- Fixed the question `BooleanList` to allow subquestion to have the same name [ASP-4228]
 
 ## 4.2.0a3 -- 2023-11-30
 

--- a/jobbergate-cli/tests/subapps/applications/test_questions.py
+++ b/jobbergate-cli/tests/subapps/applications/test_questions.py
@@ -210,6 +210,27 @@ def test_BooleanList__success(dummy_render_class, mocker):
     )
 
 
+@pytest.mark.parametrize("parent_answer", [True, False])
+def test_BooleanList__same_variable_name(dummy_render_class, parent_answer):
+    """Assert that BooleanList works when multiple children have the same variable name."""
+    variablename = "child"
+    question_a = Text(variablename, message="Question A")
+    question_b = Text(variablename, message="Question B")
+
+    question = BooleanList("parent", message="Parent", whentrue=[question_a], whenfalse=[question_b], default=False)
+    prompts = question.make_prompts()
+
+    expected_answers = {"parent": parent_answer, variablename: "any-answer"}
+    dummy_render_class.prepared_input = expected_answers
+
+    actual_answers = prompt(prompts, answers=expected_answers, render=dummy_render_class())
+    assert actual_answers == expected_answers
+
+    expected_ignored_questions = [False, not parent_answer, parent_answer]
+    actual_ignored_questions = [q.ignore for q in prompts]
+    assert actual_ignored_questions == expected_ignored_questions
+
+
 def test_gather_config_values__basic(dummy_render_class, mocker):
     variablename1 = "foo"
     question1 = Text(variablename1, message="gimme the foo!")


### PR DESCRIPTION
#### What
Fixed `BooleanList` to allow questions with the same variable name in both paths it can take.

#### Why
Fix bug reported by the users since some applications relly on it to define different paths to set the same variable.

`Task`: https://jira.scania.com/browse/ASP-4228

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
