### PR TITLE
[ASP-4113] Add constraints for API fields

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -4,11 +4,14 @@ This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
 
+- Added constraints to prevent long strings from being inserted into the database
+- Added constraints to prevent negative id numbers from being inserted into the database
 
 ## 4.2.0a6 -- 2023-12-12
 ## 4.2.0a5 -- 2023-12-12
 ## 4.2.0a4 -- 2023-12-11
 ## 4.2.0a3 -- 2023-11-30
+
 - Added support for on-site job submissions [ASP-4238]
 
 ## 4.2.0a2 -- 2023-11-29

--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 - Added constraints to prevent long strings from being inserted into the database
 - Added constraints to prevent negative id numbers from being inserted into the database
+- Added constraints to limit the size on the uploaded files
 
 ## 4.2.0a6 -- 2023-12-12
 ## 4.2.0a5 -- 2023-12-12

--- a/jobbergate-api/jobbergate_api/apps/job_script_templates/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_script_templates/schemas.py
@@ -10,7 +10,7 @@ import pydantic
 from pydantic import BaseModel
 
 from jobbergate_api.apps.constants import FileType
-from jobbergate_api.apps.schemas import TableResource
+from jobbergate_api.apps.schemas import LengthLimitedStr, TableResource
 from jobbergate_api.meta_mapper import MetaField, MetaMapper
 
 job_template_meta_mapper = MetaMapper(
@@ -107,10 +107,10 @@ class RunTimeConfig(BaseModel):
 class JobTemplateCreateRequest(BaseModel):
     """Schema for the request to create a job template."""
 
-    name: str
-    identifier: str | None
-    description: str | None
-    template_vars: dict[str, Any] | None
+    name: LengthLimitedStr
+    identifier: LengthLimitedStr | None
+    description: LengthLimitedStr | None
+    template_vars: dict[LengthLimitedStr, Any] | None
 
     class Config:
         schema_extra = job_template_meta_mapper
@@ -119,10 +119,10 @@ class JobTemplateCreateRequest(BaseModel):
 class JobTemplateUpdateRequest(BaseModel):
     """Schema for the request to update a job template."""
 
-    name: str | None
-    identifier: str | None
-    description: str | None
-    template_vars: dict[str, Any] | None
+    name: LengthLimitedStr | None
+    identifier: LengthLimitedStr | None
+    description: LengthLimitedStr | None
+    template_vars: dict[LengthLimitedStr, Any] | None
     is_archived: bool | None
 
     class Config:

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/schemas.py
@@ -5,11 +5,11 @@ from datetime import datetime
 from textwrap import dedent
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, NonNegativeInt
 
 from jobbergate_api.apps.constants import FileType
 from jobbergate_api.apps.job_script_templates.schemas import JobTemplateListView
-from jobbergate_api.apps.schemas import TableResource
+from jobbergate_api.apps.schemas import LengthLimitedStr, TableResource
 from jobbergate_api.meta_mapper import MetaField, MetaMapper
 
 job_script_meta_mapper = MetaMapper(
@@ -82,8 +82,8 @@ class JobScriptCreateRequest(BaseModel):
     Request model for creating JobScript instances.
     """
 
-    name: str
-    description: str | None
+    name: LengthLimitedStr
+    description: LengthLimitedStr | None
 
     class Config:
         schema_extra = job_script_meta_mapper
@@ -92,7 +92,7 @@ class JobScriptCreateRequest(BaseModel):
 class RenderFromTemplateRequest(BaseModel):
     """Request model for creating a JobScript entry from a template."""
 
-    template_output_name_mapping: dict[str, str]
+    template_output_name_mapping: dict[LengthLimitedStr, LengthLimitedStr]
     sbatch_params: list[str] | None
     param_dict: dict[str, Any]
 
@@ -105,8 +105,8 @@ class JobScriptUpdateRequest(BaseModel):
     Request model for updating JobScript instances.
     """
 
-    name: str | None
-    description: str | None
+    name: LengthLimitedStr | None
+    description: LengthLimitedStr | None
     is_archived: bool | None
 
     class Config:
@@ -116,8 +116,8 @@ class JobScriptUpdateRequest(BaseModel):
 class JobScriptFileDetailedView(BaseModel):
     """Model for the job_script_files field of the JobScript resource."""
 
-    parent_id: int
-    filename: str
+    parent_id: NonNegativeInt
+    filename: LengthLimitedStr
     file_type: FileType
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -266,7 +266,7 @@ class JobProperties(BaseModel, extra=Extra.forbid):
     standard_output: Optional[LengthLimitedStr] = Field(
         description="Instruct Slurm to connect the batch script's standard output directly to the file name."
     )
-    tasks: Optional[int] = Field(
+    tasks: Optional[NonNegativeInt] = Field(
         description=(
             "Advises the Slurm controller that job steps run within the allocation "
             "will launch a maximum of number tasks and to provide for sufficient resources."

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -215,7 +215,7 @@ class JobProperties(BaseModel, extra=Extra.forbid):
     memory_per_cpu: Optional[NonNegativeInt] = Field(description="Minimum real memory per cpu (MB).")
     memory_per_gpu: Optional[NonNegativeInt] = Field(description="Minimum memory required per allocated GPU.")
     memory_per_node: Optional[LengthLimitedStr] = Field(description="Minimum real memory per node (MB).")
-    minimum_cpus_per_node: Optional[int] = Field(description="Minimum number of CPUs per node.")
+    minimum_cpus_per_node: Optional[NonNegativeInt] = Field(description="Minimum number of CPUs per node.")
     minimum_nodes: Optional[bool] = Field(
         description="If a range of node counts is given, prefer the smaller count."
     )

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -287,7 +287,7 @@ class JobProperties(BaseModel, extra=Extra.forbid):
         description="Restrict node selection to nodes with at least the specified number of threads per core."
     )
     time_limit: Optional[LengthLimitedStr] = Field(description="Step time limit.")
-    time_minimum: Optional[int] = Field(description="Minimum run time in minutes.")
+    time_minimum: Optional[NonNegativeInt] = Field(description="Minimum run time in minutes.")
     wait_all_nodes: Optional[NonNegativeInt] = Field(
         description="Do not begin execution until all nodes are ready for use.", ge=0, le=1
     )

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -283,7 +283,7 @@ class JobProperties(BaseModel, extra=Extra.forbid):
             "operations and not used by the application."
         )
     )
-    threads_per_core: Optional[int] = Field(
+    threads_per_core: Optional[NonNegativeInt] = Field(
         description="Restrict node selection to nodes with at least the specified number of threads per core."
     )
     time_limit: Optional[LengthLimitedStr] = Field(description="Step time limit.")

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -288,7 +288,7 @@ class JobProperties(BaseModel, extra=Extra.forbid):
     )
     time_limit: Optional[LengthLimitedStr] = Field(description="Step time limit.")
     time_minimum: Optional[NonNegativeInt] = Field(description="Minimum run time in minutes.")
-    wait_all_nodes: Optional[NonNegativeInt] = Field(
+    wait_all_nodes: Optional[int] = Field(
         description="Do not begin execution until all nodes are ready for use.", ge=0, le=1
     )
     wckey: Optional[LengthLimitedStr] = Field(description="Specify wckey to be used with job.")

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -5,11 +5,11 @@ import re
 from pathlib import Path
 from typing import Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic import BaseModel, Extra, Field, NonNegativeInt, validator
 
 from jobbergate_api.apps.job_scripts.schemas import JobScriptDetailedView, JobScriptListView
 from jobbergate_api.apps.job_submissions.constants import JobSubmissionStatus
-from jobbergate_api.apps.schemas import TableResource
+from jobbergate_api.apps.schemas import LengthLimitedStr, TableResource
 from jobbergate_api.meta_mapper import MetaField, MetaMapper
 
 job_submission_meta_mapper = MetaMapper(
@@ -68,6 +68,10 @@ job_submission_meta_mapper = MetaMapper(
         ),
         example={"name": "job-submission-name", "comment": "I am a comment"},
     ),
+    is_archived=MetaField(
+        description="Indicates if the job submission has been archived.",
+        example=False,
+    ),
 )
 
 
@@ -78,35 +82,37 @@ class JobProperties(BaseModel, extra=Extra.forbid):
     See more details at: https://slurm.schedmd.com/rest_api.html
     """
 
-    account: Optional[str] = Field(
+    account: Optional[LengthLimitedStr] = Field(
         description="Charge resources used by this job to specified account.",
     )
-    account_gather_frequency: Optional[str] = Field(
+    account_gather_frequency: Optional[LengthLimitedStr] = Field(
         description="Define the job accounting and profiling sampling intervals.",
     )
-    argv: Optional[List[str]] = Field(description="Arguments to the script.")
-    array: Optional[str] = Field(
+    argv: Optional[List[LengthLimitedStr]] = Field(description="Arguments to the script.")
+    array: Optional[LengthLimitedStr] = Field(
         description=(
             "Submit a job array, multiple jobs to be executed with identical parameters. "
             "The indexes specification identifies what array index values should be used."
         )
     )
-    batch_features: Optional[str] = Field(description="features required for batch script's node")
-    begin_time: Optional[str] = Field(
+    batch_features: Optional[LengthLimitedStr] = Field(
+        description="features required for batch script's node"
+    )
+    begin_time: Optional[LengthLimitedStr] = Field(
         description=(
             "Submit the batch script to the Slurm controller immediately, like normal, "
             "but tell the controller to defer the allocation of the job until the specified time."
         )
     )
-    burst_buffer: Optional[str] = Field(description="Burst buffer specification.")
-    cluster_constraints: Optional[str] = Field(
+    burst_buffer: Optional[LengthLimitedStr] = Field(description="Burst buffer specification.")
+    cluster_constraints: Optional[LengthLimitedStr] = Field(
         description=(
             "Specifies features that a federated cluster must have to have a sibling job submitted to it."
         )
     )
-    comment: Optional[str] = Field(description="An arbitrary comment.")
-    constraints: Optional[str] = Field(description="node features required by job.")
-    container: Optional[str] = Field(description="Absolute path to OCI container bundle.")
+    comment: Optional[LengthLimitedStr] = Field(description="An arbitrary comment.")
+    constraints: Optional[LengthLimitedStr] = Field(description="node features required by job.")
+    container: Optional[LengthLimitedStr] = Field(description="Absolute path to OCI container bundle.")
     core_specification: Optional[int] = Field(
         description=(
             "Count of specialized threads per node reserved by the job for system "
@@ -118,26 +124,28 @@ class JobProperties(BaseModel, extra=Extra.forbid):
             "Restrict node selection to nodes with at least the specified number of cores per socket."
         )
     )
-    cpu_binding: Optional[str] = Field(description="Cpu binding")
-    cpu_binding_hint: Optional[str] = Field(description="Cpu binding hint")
-    cpu_frequency: Optional[str] = Field(
+    cpu_binding: Optional[LengthLimitedStr] = Field(description="Cpu binding")
+    cpu_binding_hint: Optional[LengthLimitedStr] = Field(description="Cpu binding hint")
+    cpu_frequency: Optional[LengthLimitedStr] = Field(
         description=(
             "Request that job steps initiated by srun commands inside this sbatch "
             "script be run at some requested frequency if possible, on the CPUs "
             "selected for the step on the compute node(s)."
         ),
     )
-    cpus_per_gpu: Optional[str] = Field(description="Number of CPUs requested per allocated GPU.")
+    cpus_per_gpu: Optional[LengthLimitedStr] = Field(
+        description="Number of CPUs requested per allocated GPU."
+    )
     cpus_per_task: Optional[int] = Field(
         description=(
             "Advise the Slurm controller that ensuing job steps will require "
             "ncpus number of processors per task."
         ),
     )
-    current_working_directory: Optional[str] = Field(
+    current_working_directory: Optional[LengthLimitedStr] = Field(
         description="Instruct Slurm to connect the batch script's standard output directly to the file name."
     )
-    deadline: Optional[str] = Field(
+    deadline: Optional[LengthLimitedStr] = Field(
         description=(
             "Remove the job if no ending is possible before this deadline (start > (deadline - time[-min]))."
         )
@@ -148,15 +156,17 @@ class JobProperties(BaseModel, extra=Extra.forbid):
             "the job has been eligible to run for less than this time period."
         )
     )
-    dependency: Optional[str] = Field(
+    dependency: Optional[LengthLimitedStr] = Field(
         description=(
             "Defer the start of this job until the specified dependencies have been satisfied completed."
         )
     )
-    distribution: Optional[str] = Field(
+    distribution: Optional[LengthLimitedStr] = Field(
         description="Specify alternate distribution methods for remote processes."
     )
-    environment: Optional[Dict[str, str]] = Field(description="Dictionary of environment entries.")
+    environment: Optional[Dict[LengthLimitedStr, LengthLimitedStr]] = Field(
+        description="Dictionary of environment entries."
+    )
     exclusive: Optional[Literal["user", "mcs", "exclusive", "oversubscribe"]] = Field(
         description=(
             "The job allocation can share nodes just other users with the "
@@ -168,64 +178,72 @@ class JobProperties(BaseModel, extra=Extra.forbid):
         ge=0,
         le=1,
     )
-    gres: Optional[str] = Field(
+    gres: Optional[LengthLimitedStr] = Field(
         description="Specifies a comma delimited list of generic consumable resources."
     )
     gres_flags: Optional[Literal["disable-binding", "enforce-binding"]] = Field(
         description="Specify generic resource task binding options."
     )
-    gpu_binding: Optional[str] = Field(description="Requested binding of tasks to GPU.")
-    gpu_frequency: Optional[str] = Field(description="Requested GPU frequency.")
-    gpus: Optional[str] = Field(description="GPUs per job.")
-    gpus_per_node: Optional[str] = Field(description="GPUs per node.")
-    gpus_per_socket: Optional[str] = Field(description="GPUs per socket.")
-    gpus_per_task: Optional[str] = Field(description="GPUs per task.")
+    gpu_binding: Optional[LengthLimitedStr] = Field(description="Requested binding of tasks to GPU.")
+    gpu_frequency: Optional[LengthLimitedStr] = Field(description="Requested GPU frequency.")
+    gpus: Optional[LengthLimitedStr] = Field(description="GPUs per job.")
+    gpus_per_node: Optional[LengthLimitedStr] = Field(description="GPUs per node.")
+    gpus_per_socket: Optional[LengthLimitedStr] = Field(description="GPUs per socket.")
+    gpus_per_task: Optional[LengthLimitedStr] = Field(description="GPUs per task.")
     hold: Optional[bool] = Field(
         description="Specify the job is to be submitted in a held state (priority of zero)."
     )
     kill_on_invalid_dependency: Optional[bool] = Field(
         description="If a job has an invalid dependency, then Slurm is to terminate it."
     )
-    licenses: Optional[str] = Field(
+    licenses: Optional[LengthLimitedStr] = Field(
         description=(
             "Specification of licenses (or other resources available on all nodes of the cluster) "
             "which must be allocated to this job."
         )
     )
-    mail_type: Optional[str] = Field(description="Notify user by email when certain event types occur.")
-    mail_user: Optional[str] = Field(
+    mail_type: Optional[LengthLimitedStr] = Field(
+        description="Notify user by email when certain event types occur."
+    )
+    mail_user: Optional[LengthLimitedStr] = Field(
         description="User to receive email notification of state changes as defined by mail_type."
     )
-    mcs_label: Optional[str] = Field(description="This parameter is a group among the groups of the user.")
-    memory_binding: Optional[str] = Field(description="Bind tasks to memory.")
+    mcs_label: Optional[LengthLimitedStr] = Field(
+        description="This parameter is a group among the groups of the user."
+    )
+    memory_binding: Optional[LengthLimitedStr] = Field(description="Bind tasks to memory.")
     memory_per_cpu: Optional[int] = Field(description="Minimum real memory per cpu (MB).")
     memory_per_gpu: Optional[int] = Field(description="Minimum memory required per allocated GPU.")
-    memory_per_node: Optional[str] = Field(description="Minimum real memory per node (MB).")
+    memory_per_node: Optional[LengthLimitedStr] = Field(description="Minimum real memory per node (MB).")
     minimum_cpus_per_node: Optional[int] = Field(description="Minimum number of CPUs per node.")
     minimum_nodes: Optional[bool] = Field(
         description="If a range of node counts is given, prefer the smaller count."
     )
-    name: Optional[str] = Field(description="Specify a name for the job allocation.")
-    nice: Optional[str] = Field(description="Run the job with an adjusted scheduling priority within Slurm.")
+    name: Optional[LengthLimitedStr] = Field(description="Specify a name for the job allocation.")
+    nice: Optional[LengthLimitedStr] = Field(
+        description="Run the job with an adjusted scheduling priority within Slurm."
+    )
     no_kill: Optional[bool] = Field(
         description="Do not automatically terminate a job if one of the nodes it has been allocated fails."
     )
-    nodes: Optional[str] = Field(
+    nodes: Optional[LengthLimitedStr] = Field(
         description="Request that a minimum of nodes nodes and a maximum node count.",
     )
     open_mode: Optional[Literal["append", "truncate"]] = Field(
         description="Open the output and error files using append or truncate mode as specified."
     )
-    partition: Optional[str] = Field(description="Request a specific partition for the resource allocation.")
-    priority: Optional[str] = Field(description="Request a specific job priority.")
-    qos: Optional[str] = Field(description="Request a quality of service for the job.")
+    partition: Optional[LengthLimitedStr] = Field(
+        description="Request a specific partition for the resource allocation."
+    )
+    priority: Optional[LengthLimitedStr] = Field(description="Request a specific job priority.")
+    qos: Optional[LengthLimitedStr] = Field(description="Request a quality of service for the job.")
     requeue: Optional[bool] = Field(
         description="Specifies that the batch job should eligible to being requeue."
     )
-    reservation: Optional[str] = Field(
+    reservation: Optional[LengthLimitedStr] = Field(
         description="Allocate resources for the job from the named reservation."
     )
-    signal: Optional[str] = Field(
+    signal: Optional[LengthLimitedStr] = Field(
         description="When a job is within sig_time seconds of its end time, send it the signal sig_num.",
     )
     sockets_per_node: Optional[int] = Field(
@@ -237,15 +255,15 @@ class JobProperties(BaseModel, extra=Extra.forbid):
             "to evenly distribute tasks across the allocated nodes."
         )
     )
-    standard_error: Optional[str] = Field(
+    standard_error: Optional[LengthLimitedStr] = Field(
         description="Instruct Slurm to connect the batch script's standard error directly to the file name."
     )
-    standard_input: Optional[str] = Field(
+    standard_input: Optional[LengthLimitedStr] = Field(
         description=(
             "Instruct Slurm to connect the batch script's standard input directly to the file name specified."
         )
     )
-    standard_output: Optional[str] = Field(
+    standard_output: Optional[LengthLimitedStr] = Field(
         description="Instruct Slurm to connect the batch script's standard output directly to the file name."
     )
     tasks: Optional[int] = Field(
@@ -268,12 +286,12 @@ class JobProperties(BaseModel, extra=Extra.forbid):
     threads_per_core: Optional[int] = Field(
         description="Restrict node selection to nodes with at least the specified number of threads per core."
     )
-    time_limit: Optional[str] = Field(description="Step time limit.")
+    time_limit: Optional[LengthLimitedStr] = Field(description="Step time limit.")
     time_minimum: Optional[int] = Field(description="Minimum run time in minutes.")
     wait_all_nodes: Optional[int] = Field(
         description="Do not begin execution until all nodes are ready for use.", ge=0, le=1
     )
-    wckey: Optional[str] = Field(description="Specify wckey to be used with job.")
+    wckey: Optional[LengthLimitedStr] = Field(description="Specify wckey to be used with job.")
 
     @validator("signal", pre=True)
     def _backward_compatibility_on_signal(cls, value):
@@ -301,12 +319,12 @@ class JobSubmissionCreateRequest(BaseModel):
     Request model for creating JobSubmission instances.
     """
 
-    name: str
-    description: Optional[str]
-    job_script_id: int
-    slurm_job_id: Optional[int]
-    execution_directory: Optional[str]
-    client_id: Optional[str]
+    name: LengthLimitedStr
+    description: Optional[LengthLimitedStr]
+    job_script_id: NonNegativeInt
+    slurm_job_id: Optional[NonNegativeInt]
+    execution_directory: Optional[LengthLimitedStr]
+    client_id: Optional[LengthLimitedStr]
     execution_parameters: JobProperties = Field(default_factory=JobProperties)
 
     class Config:
@@ -318,9 +336,9 @@ class JobSubmissionUpdateRequest(BaseModel):
     Request model for updating JobSubmission instances.
     """
 
-    name: Optional[str]
-    description: Optional[str]
-    execution_directory: Optional[str]
+    name: Optional[LengthLimitedStr]
+    description: Optional[LengthLimitedStr]
+    execution_directory: Optional[LengthLimitedStr]
     status: Optional[JobSubmissionStatus]
 
     class Config:
@@ -331,8 +349,8 @@ class JobSubmissionAgentUpdateRequest(BaseModel):
     """Request model for updating JobSubmission instances."""
 
     status: JobSubmissionStatus
-    slurm_job_id: Optional[int]
-    report_message: Optional[str]
+    slurm_job_id: Optional[NonNegativeInt]
+    report_message: Optional[LengthLimitedStr]
 
     class Config:
         schema_extra = job_submission_meta_mapper

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -212,8 +212,8 @@ class JobProperties(BaseModel, extra=Extra.forbid):
         description="This parameter is a group among the groups of the user."
     )
     memory_binding: Optional[LengthLimitedStr] = Field(description="Bind tasks to memory.")
-    memory_per_cpu: Optional[int] = Field(description="Minimum real memory per cpu (MB).")
-    memory_per_gpu: Optional[int] = Field(description="Minimum memory required per allocated GPU.")
+    memory_per_cpu: Optional[NonNegativeInt] = Field(description="Minimum real memory per cpu (MB).")
+    memory_per_gpu: Optional[NonNegativeInt] = Field(description="Minimum memory required per allocated GPU.")
     memory_per_node: Optional[LengthLimitedStr] = Field(description="Minimum real memory per node (MB).")
     minimum_cpus_per_node: Optional[int] = Field(description="Minimum number of CPUs per node.")
     minimum_nodes: Optional[bool] = Field(

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -288,7 +288,7 @@ class JobProperties(BaseModel, extra=Extra.forbid):
     )
     time_limit: Optional[LengthLimitedStr] = Field(description="Step time limit.")
     time_minimum: Optional[int] = Field(description="Minimum run time in minutes.")
-    wait_all_nodes: Optional[int] = Field(
+    wait_all_nodes: Optional[NonNegativeInt] = Field(
         description="Do not begin execution until all nodes are ready for use.", ge=0, le=1
     )
     wckey: Optional[LengthLimitedStr] = Field(description="Specify wckey to be used with job.")

--- a/jobbergate-api/jobbergate_api/apps/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/schemas.py
@@ -1,17 +1,14 @@
 """Define app-wide, reusable pydantic schemas."""
 
-from typing import Any
+from typing import Annotated, Any
 
 import sqlalchemy
 from pendulum.datetime import DateTime
-from pydantic import BaseModel, ConstrainedStr
+from pydantic import BaseModel, Field
 from pydantic.utils import GetterDict
 
-
-class LengthLimitedStr(ConstrainedStr):
-    """A custom ConstrainedStr to limit the length of a string."""
-
-    max_length = 255
+# Make both Pydantic and mypy happy:
+LengthLimitedStr = Annotated[str, Field(max_length=255)]
 
 
 class IgnoreLazyGetterDict(GetterDict):

--- a/jobbergate-api/jobbergate_api/apps/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/schemas.py
@@ -4,8 +4,14 @@ from typing import Any
 
 import sqlalchemy
 from pendulum.datetime import DateTime
-from pydantic import BaseModel
+from pydantic import BaseModel, ConstrainedStr
 from pydantic.utils import GetterDict
+
+
+class LengthLimitedStr(ConstrainedStr):
+    """A custom ConstrainedStr to limit the length of a string."""
+
+    max_length = 255
 
 
 class IgnoreLazyGetterDict(GetterDict):
@@ -67,7 +73,7 @@ class ListParams(BaseModel):
 
     sort_ascending: bool = True
     user_only: bool = False
-    search: str | None
-    sort_field: str | None
+    search: LengthLimitedStr | None
+    sort_field: LengthLimitedStr | None
     include_archived: bool = False
     include_parent: bool = False

--- a/jobbergate-api/jobbergate_api/apps/services.py
+++ b/jobbergate-api/jobbergate_api/apps/services.py
@@ -8,7 +8,7 @@ from typing import Any, Generic, Protocol, TypeVar
 
 from botocore.response import StreamingBody
 from buzz import check_expressions, enforce_defined, handle_errors, require_condition
-from fastapi import HTTPException, UploadFile, status
+from fastapi import HTTPException, status
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlalchemy import paginate
 from jinja2 import Template
@@ -19,7 +19,9 @@ from sqlalchemy.engine import Result
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped
 from sqlalchemy.sql.expression import Select
+from starlette.datastructures import UploadFile
 
+from jobbergate_api.config import settings
 from jobbergate_api.safe_types import Bucket
 from jobbergate_api.storage import render_sql, search_clause, sort_clause
 
@@ -528,12 +530,27 @@ class FileService(DatabaseBoundService, BucketBoundService, Generic[FileModel]):
 
         if isinstance(upload_content, str):
             file_obj: Any = io.BytesIO(upload_content.encode())
+            size = file_obj.getbuffer().nbytes
         elif isinstance(upload_content, bytes):
             file_obj = io.BytesIO(upload_content)
-        elif hasattr(upload_content, "file"):
+            size = file_obj.getbuffer().nbytes
+        elif isinstance(upload_content, UploadFile):
             file_obj = upload_content.file
+            size = enforce_defined(
+                upload_content.size,  # double checking just because it can be None
+                "UploadFile has no size attribute",
+                raise_exc_class=ServiceError,
+                raise_kwargs=dict(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR),
+            )
         else:
             raise TypeError(f"Unsupported file type {type(upload_content)}")
+
+        require_condition(
+            size <= settings.MAX_UPLOAD_FILE_SIZE,
+            f"Uploaded files cannot exceed {settings.MAX_UPLOAD_FILE_SIZE} bytes, got {size} bytes",
+            raise_exc_class=ServiceError,
+            raise_kwargs=dict(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE),
+        )
 
         # Mypy doesn't like aioboto3 much
         await self.bucket.upload_fileobj(Fileobj=file_obj, Key=instance.file_key)  # type: ignore

--- a/jobbergate-api/jobbergate_api/apps/services.py
+++ b/jobbergate-api/jobbergate_api/apps/services.py
@@ -8,7 +8,7 @@ from typing import Any, Generic, Protocol, TypeVar
 
 from botocore.response import StreamingBody
 from buzz import check_expressions, enforce_defined, handle_errors, require_condition
-from fastapi import HTTPException, status
+from fastapi import HTTPException, UploadFile, status
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlalchemy import paginate
 from jinja2 import Template
@@ -19,7 +19,6 @@ from sqlalchemy.engine import Result
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped
 from sqlalchemy.sql.expression import Select
-from starlette.datastructures import UploadFile
 
 from jobbergate_api.config import settings
 from jobbergate_api.safe_types import Bucket
@@ -534,7 +533,7 @@ class FileService(DatabaseBoundService, BucketBoundService, Generic[FileModel]):
         elif isinstance(upload_content, bytes):
             file_obj = io.BytesIO(upload_content)
             size = file_obj.getbuffer().nbytes
-        elif isinstance(upload_content, UploadFile):
+        elif hasattr(upload_content, "file") and hasattr(upload_content, "size"):
             file_obj = upload_content.file
             size = enforce_defined(
                 upload_content.size,  # double checking just because it can be None

--- a/jobbergate-api/jobbergate_api/config.py
+++ b/jobbergate-api/jobbergate_api/config.py
@@ -86,7 +86,7 @@ class Settings(BaseSettings):
     SENTRY_TRACING_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
 
     # Maximum number of bytes allowed for file uploads
-    MAX_UPLOAD_FILE_SIZE: int = 100 * 1024 * 1024  # 100 MB
+    MAX_UPLOAD_FILE_SIZE: int = 5 * 1024 * 1024  # 100 MB
 
     # Sendgrid configuration for email notification
     SENDGRID_FROM_EMAIL: Optional[str]

--- a/jobbergate-api/tests/apps/test_schemas.py
+++ b/jobbergate-api/tests/apps/test_schemas.py
@@ -1,0 +1,33 @@
+import pytest
+from pydantic import ValidationError
+
+from jobbergate_api.apps.schemas import BaseModel, LengthLimitedStr
+
+
+class TestLengthLimitedStr:
+    """
+    Test the LengthLimitedStr type alias.
+    """
+
+    class DummySchema(BaseModel):
+        """
+        A dummy schema to test the LengthLimitedStr type alias.
+        """
+
+        name: LengthLimitedStr
+
+    def test_valid(self):
+        """
+        Test that short strings are accepted.
+        """
+        expected_name = "a" * 255
+        schema = self.DummySchema(name=expected_name)
+        assert isinstance(schema.name, str)
+        assert schema.name == expected_name
+
+    def test_invalid(self):
+        """
+        Test that long strings are rejected.
+        """
+        with pytest.raises(ValidationError):
+            self.DummySchema(name="a" * 256)


### PR DESCRIPTION
#### What
This aims to keep file and string sizes under control, and with that, the functionality of Jobbergate as a whole.

#### Why
As a Jobbergate maintainer, I want add constrains to fields in the API, so that arbitrary large texts are not inserted into the database.

`Task`: https://jira.scania.com/browse/ASP-4113

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
