### PR TITLE
[PENG-2000] Report communication errors to Sentry

### DIFF
--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -4,13 +4,19 @@ This file keeps track of all notable changes to jobbergate-core
 
 ## Unreleased
 
+- Capture request errors with Slurm API in Sentry notifications [PENG-2000]
+- Capture request errors with Jobbergate API in Sentry notifications [PENG-2000]
 
 ## 4.2.0a7 -- 2023-12-13
+
 ## 4.2.0a6 -- 2023-12-12
+
 ## 4.2.0a5 -- 2023-12-12
+
 - Added support for Python 3.12
 
 ## 4.2.0a4 -- 2023-12-11
+
 ## 4.2.0a3 -- 2023-11-30
 
 ## 4.2.0a2 -- 2023-11-29

--- a/jobbergate-agent/jobbergate_agent/jobbergate/finish.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/finish.py
@@ -11,11 +11,9 @@ from jobbergate_agent.utils.logging import log_error
 async def fetch_job_status(slurm_job_id: int) -> SlurmSubmittedJobStatus:
     logger.debug(f"Fetching slurm job status for slurm job {slurm_job_id}")
 
-    with SlurmrestdError.handle_errors(
-        "Failed to fetch job status from slurm",
-        do_except=log_error,
-    ):
-        response = await slurmrestd_client.get(f"/job/{slurm_job_id}")
+    response = await slurmrestd_client.get(f"/job/{slurm_job_id}")
+
+    with SlurmrestdError.handle_errors("Failed to fetch job status from slurm", do_except=log_error):
         response.raise_for_status()
         data = response.json()
 
@@ -48,10 +46,7 @@ async def finish_active_jobs():
             logger.debug(f"Fetch status failed...{skip}")
             continue
 
-        if status.jobbergate_status not in {
-            JobSubmissionStatus.COMPLETED,
-            JobSubmissionStatus.FAILED,
-        }:
+        if status.jobbergate_status not in {JobSubmissionStatus.COMPLETED, JobSubmissionStatus.FAILED}:
             logger.debug(f"Job is not complete or failed...{skip}")
             continue
 


### PR DESCRIPTION
#### What
Make sure communication errors with Slurm REST API and Jobbergate API result in sentry notifications.

#### Why
Request errors were all captured and handled internally, resulting in no notifications for the support team. This PR fixes that. 

`Task`: https://app.clickup.com/t/18022949/PENG-2000

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
