### PR TITLE
fix(agent): add job property for compatibility

### DIFF
--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -4,8 +4,10 @@ This file keeps track of all notable changes to jobbergate-core
 
 ## Unreleased
 
+- Added the job property `environment` since it is required when configured to interact with slurm rest `0.0.39`
 
 ## 4.2.1a0 -- 2024-01-11
+
 - Map job submissions with cancelled status [ASP-4288]
 
 ## 4.2.0 -- 2024-01-08

--- a/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
@@ -45,6 +45,9 @@ def get_job_parameters(slurm_parameters: Dict[str, Any], **kwargs) -> SlurmJobPa
     values from slurm_parameters.
     """
     merged_parameters = {**kwargs, **slurm_parameters}
+    if SETTINGS.SLURM_RESTD_VERSION == "v0.0.39":
+        # add required environment variable for slurmrestd v0.0.39
+        merged_parameters.setdefault("environment", []).append("FOO=bar")
     return SlurmJobParams.parse_obj(merged_parameters)
 
 


### PR DESCRIPTION
#### What
Add job property `environment` when running on slurm restd 0.0.39

#### Why
For compatibility with slurm restd 0.0.39

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
