### PR TITLE
[ASP-4557] Allow methods from JobbergateBaseApplication to return None

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,8 +4,10 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 
+- Allow methods from `JobbergateBaseApplication` to return None for backward compatibility [ASP-4557]
 
 ## 4.3.0a0 -- 2024-01-15
+
 - Improved error handling and reporting [ASP-4095]
 
 ## 4.2.1a0 -- 2024-01-11

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/questions.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/questions.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, Optional, Type, TypeVar, cast
 import inquirer
 import inquirer.errors
 import inquirer.questions
+from loguru import logger
 
 from jobbergate_cli.exceptions import Abort
 from jobbergate_cli.render import render_dict
@@ -347,6 +348,12 @@ def gather_param_values(
 
         prompts = []
         auto_answers = {}
+
+        if workflow_questions is None:
+            logger.warning(
+                "Deprecation warning: Application method {} returned None while a list is expected", next_method
+            )
+            workflow_questions = []
 
         for question in workflow_questions:
             if question.variablename in supplied_params:

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
@@ -20,6 +20,7 @@ from jobbergate_cli.constants import (
     FileType,
 )
 from jobbergate_cli.exceptions import Abort
+from jobbergate_cli.render import terminal_message
 from jobbergate_cli.requests import make_request
 from jobbergate_cli.schemas import ApplicationResponse, JobbergateApplicationConfig, JobbergateConfig, JobbergateContext
 from jobbergate_cli.subapps.applications.application_base import JobbergateApplicationBase
@@ -369,6 +370,15 @@ def execute_application(
     :param: fast_mode:       If true, do not ask the user questions. Just use supplied_params or defaults
     :returns: The configuration values collected from the user by executing the application
     """
-    app_params = gather_param_values(app_module, supplied_params=supplied_params, fast_mode=fast_mode)
+    try:
+        app_params = gather_param_values(app_module, supplied_params=supplied_params, fast_mode=fast_mode)
+    except Exception as err:
+        exception_name = type(err).__name__
+        terminal_message(
+            "The question workflow failed to execute. Please check the traceback bellow for more information.",
+            subject=f"Runtime error on application execution - {exception_name}",
+            color="red",
+        )
+        raise err
     app_config.application_config.update(**app_params)
     return app_params


### PR DESCRIPTION
#### What
As a Jobbergate maintainer, I want to allow None as an valid return type for the question workflows on Jobbergate applications, so that these applications can run on next-gen Jobbergate with no problem.

#### Why

Some legacy Jobbergate applications return `None` from its question workflow resulting in a `TypeError: 'NoneType' object is not iterable` on next-gen Jobbergate since Jobbergate expects the returning object to be specifically a list.

Due to differences on the implementation details, jobbergate-legacy does not raise an error in this case and so legacy applications expect the same from next-gen Jobbergate.

`Task`: https://jira.scania.com/browse/ASP-4557

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
