### PR TITLE
[ASP-4558] Allow application script to dynamically overwrite job-script's name

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -5,6 +5,7 @@ This file keeps track of all notable changes to jobbergate-cli
 ## Unreleased
 
 - Allow methods from `JobbergateBaseApplication` to return None for backward compatibility [ASP-4557]
+- Allow application script to dynamically overwrite job-script's name [ASP-4558]
 
 ## 4.3.0a0 -- 2024-01-15
 

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -71,11 +71,6 @@ class JobbergateConfig(pydantic.BaseModel, extra=pydantic.Extra.allow):
     supporting_files_output_name: Optional[Dict[str, List[str]]] = None
     supporting_files: Optional[List[str]] = None
 
-    # For some reason, we support the application_config being about to override the *required*
-    # job_script_name parameter that is passed at job_script creation time.
-    # TODO: Find if this functionality is every used, and, if not, remove it immediately.
-    job_script_name: Optional[str] = None
-
     @pydantic.root_validator(pre=True)
     def compute_extra_settings(cls, values):
         """

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
@@ -237,6 +237,12 @@ def render_job_script(
     param_dict_flat = flatten_param_dict(app_config.dict())
 
     job_script_name = name if name else app_data.name
+
+    if param_dict_flat.get("job_script_name"):
+        # Possibly overwrite script name if set at runtime by the application
+        job_script_name = param_dict_flat["job_script_name"]
+        logger.debug("Job script name was set by the application at runtime: {}", job_script_name)
+
     request_data = JobScriptRenderRequestData(
         create_request=JobScriptCreateRequest(
             name=job_script_name,
@@ -250,9 +256,6 @@ def render_job_script(
             param_dict={"data": param_dict_flat},
         ),
     )
-
-    if app_config.jobbergate_config.job_script_name is not None:
-        request_data.create_request.name = app_config.jobbergate_config.job_script_name
 
     # Make static type checkers happy
     assert jg_ctx.client is not None

--- a/jobbergate-cli/tests/subapps/applications/test_tools.py
+++ b/jobbergate-cli/tests/subapps/applications/test_tools.py
@@ -169,7 +169,6 @@ def test_load_application_from_source__success(dummy_module_source, dummy_jobber
         output_directory=pathlib.Path("."),
         supporting_files=None,
         supporting_files_output_name=None,
-        job_script_name=None,
         user_supplied_key="user-supplied-value",
     )
     assert application.application_config == dict(

--- a/jobbergate-cli/tests/subapps/conftest.py
+++ b/jobbergate-cli/tests/subapps/conftest.py
@@ -240,7 +240,6 @@ def dummy_config_source():
           output_directory: .
           supporting_files_output_name:
           supporting_files:
-          job_script_name:
           user_supplied_key: user-supplied-value
         application_config:
           foo: foo

--- a/jobbergate-cli/tests/subapps/job_scripts/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_app.py
@@ -301,7 +301,6 @@ def test_render__non_fast_mode_and_job_submission(
                     "output_directory": ".",
                     "supporting_files_output_name": None,
                     "supporting_files": None,
-                    "job_script_name": None,
                 }
             },
         },
@@ -420,7 +419,6 @@ def test_render__with_fast_mode_and_no_job_submission(
                     "output_directory": ".",
                     "supporting_files_output_name": None,
                     "supporting_files": None,
-                    "job_script_name": None,
                 }
             },
         },


### PR DESCRIPTION
#### What
As a a Jobbergate maintainer, I want to allow application scripts to dynamically overwrite the name of the job-script rendered from it, so that the filename is consistent to what the users are used to from jobbergate-legacy.

#### Why
It was identified that the Abaqus application on Jobbergate asks the user for the name of the job, and that the user provided value is expected to overwrite the original name. This ultimately results in the job-script files being named according to it, since they follow the schema `<job_script_name>.job`.

This is consistent with the logic on jobbergate-legacy.

`Task`: https://jira.scania.com/browse/ASP-4558

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
