### PR TITLE
PENG-2045 Fixed cluster_name presentation in multi-tenancy mode

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
+-  Fixed cluster_name presentation in multi-tenancy mode [PENG-2045]
 
 
 ## 4.3.0a0 -- 2024-01-15

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -67,6 +67,9 @@ class Settings(BaseSettings):
     OIDC_USE_HTTPS: bool = True
     OIDC_MAX_POLL_TIME: int = 5 * 60  # 5 Minutes
 
+    # Enable multi-tenancy to fix cluster name mapping by client_id
+    MULTI_TENANCY_ENABLED: bool = False
+
     @root_validator(skip_on_failure=True)
     def compute_extra_settings(cls, values):
         """

--- a/jobbergate-cli/jobbergate_cli/exceptions.py
+++ b/jobbergate-cli/jobbergate_cli/exceptions.py
@@ -47,7 +47,7 @@ class Abort(buzz.Buzz):
         **kwargs,
     ):
         """
-        Initialize the Abort errror.
+        Initialize the Abort error.
         """
         self.subject = subject
         self.support = support

--- a/jobbergate-cli/jobbergate_cli/requests.py
+++ b/jobbergate-cli/jobbergate_cli/requests.py
@@ -250,7 +250,7 @@ def make_request(
     if response_model_cls is None:
         return data
 
-    logger.debug("Validating response data with ResponseModel")
+    logger.debug(f"Validating response data with {response_model_cls}")
     try:
         return response_model_cls(**data)
     except pydantic.ValidationError as err:

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -4,10 +4,11 @@ Provide Pydantic models for various data items.
 
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 import httpx
 import pydantic
+import pydantic.generics
 
 
 class TokenSet(pydantic.BaseModel, extra=pydantic.Extra.ignore):
@@ -26,6 +27,7 @@ class IdentityData(pydantic.BaseModel):
 
     email: str
     client_id: str
+    organization_id: Optional[str]
 
 
 class Persona(pydantic.BaseModel):
@@ -245,12 +247,15 @@ class JobSubmissionCreateRequestData(pydantic.BaseModel):
     execution_parameters: Dict[str, Any] = pydantic.Field(default_factory=dict)
 
 
-class ListResponseEnvelope(pydantic.BaseModel):
+EnvelopeT = TypeVar("EnvelopeT")
+
+
+class ListResponseEnvelope(pydantic.generics.GenericModel, Generic[EnvelopeT]):
     """
     A model describing the structure of response envelopes from "list" endpoints.
     """
 
-    items: List[Dict[str, Any]]
+    items: List[EnvelopeT]
     total: int
     page: int
     size: int

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -12,7 +12,7 @@ from jobbergate_cli.constants import SortOrder
 from jobbergate_cli.exceptions import handle_abort
 from jobbergate_cli.render import StyleMapper, render_single_result, terminal_message
 from jobbergate_cli.requests import make_request
-from jobbergate_cli.schemas import JobbergateContext
+from jobbergate_cli.schemas import JobbergateContext, JobSubmissionResponse
 from jobbergate_cli.subapps.job_submissions.tools import create_job_submission, fetch_job_submission_data
 from jobbergate_cli.subapps.pagination import handle_pagination
 
@@ -89,9 +89,6 @@ def create(
     """
     jg_ctx: JobbergateContext = ctx.obj
 
-    # Make static type checkers happy
-    assert jg_ctx.client is not None, "Client is uninitialized"
-
     result = create_job_submission(
         jg_ctx,
         job_script_id,
@@ -136,6 +133,7 @@ def list_all(
     # Make static type checkers happy
     assert jg_ctx is not None, "JobbergateContext is uninitialized"
     assert jg_ctx.client is not None, "Client is uninitialized"
+    assert jg_ctx.persona is not None, "Persona is uninitialized"
 
     params: Dict[str, Any] = dict(user_only=not show_all)
     if search is not None:
@@ -147,6 +145,11 @@ def list_all(
     if from_job_script_id is not None:
         params["from_job_script_id"] = from_job_script_id
 
+    value_mappers = None
+    organization_id = jg_ctx.persona.identity_data.organization_id
+    if organization_id is not None:
+        value_mappers = dict(cluster_name=lambda cn: cn.replace(f"-{organization_id}", ""))
+
     handle_pagination(
         jg_ctx=jg_ctx,
         url_path="/jobbergate/job-submissions",
@@ -155,6 +158,8 @@ def list_all(
         title="Job Submission List",
         style_mapper=style_mapper,
         hidden_fields=HIDDEN_FIELDS,
+        nested_response_model_cls=JobSubmissionResponse,
+        value_mappers=value_mappers,
     )
 
 
@@ -168,12 +173,23 @@ def get_one(
     Get a single job submission by id
     """
     jg_ctx: JobbergateContext = ctx.obj
+
+    # Make static type checkers happy
+    assert jg_ctx is not None, "JobbergateContext is uninitialized"
+    assert jg_ctx.persona is not None, "Persona is uninitialized"
+
+    value_mappers = None
+    organization_id = jg_ctx.persona.identity_data.organization_id
+    if organization_id is not None:
+        value_mappers = dict(cluster_name=lambda cn: cn.replace(f"-{organization_id}", ""))
+
     result = fetch_job_submission_data(jg_ctx, id)
     render_single_result(
         jg_ctx,
         result,
         hidden_fields=HIDDEN_FIELDS,
         title="Job Submission",
+        value_mappers=value_mappers,
     )
 
 

--- a/jobbergate-cli/pyproject.toml
+++ b/jobbergate-cli/pyproject.toml
@@ -70,6 +70,7 @@ env = [
     "OIDC_DOMAIN = dummy_auth_domain.com",
     "OIDC_AUDIENCE = https://dummy_auth_audience.com",
     "OIDC_CLIENT_ID = dummy_client_id",
+    "MULTI_TENANCY_ENABLED = false"
 ]
 
 [tool.black]

--- a/jobbergate-cli/tests/conftest.py
+++ b/jobbergate-cli/tests/conftest.py
@@ -47,8 +47,10 @@ def tweak_settings():
         for key, value in kwargs.items():
             previous_values[key] = getattr(settings, key)
             setattr(settings, key, value)
-        yield
-        for key, value in previous_values.items():
-            setattr(settings, key, value)
+        try:
+            yield
+        finally:
+            for key, value in previous_values.items():
+                setattr(settings, key, value)
 
     return _helper

--- a/jobbergate-cli/tests/subapps/conftest.py
+++ b/jobbergate-cli/tests/subapps/conftest.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 import httpx
 import pytest
@@ -46,13 +46,18 @@ def dummy_context(dummy_domain):
 
 @pytest.fixture
 def attach_persona(dummy_context):
-    def _helper(email: str, client_id: str = "dummy-client", access_token: str = "foo"):
+    def _helper(
+        email: str, client_id: str = "dummy-client", access_token: str = "foo", organization_id: Optional[str] = None
+    ):
+        identity_data = IdentityData(
+            client_id=client_id,
+            email=email,
+        )
+        if organization_id is not None:
+            identity_data.organization_id = organization_id
         dummy_context.persona = Persona(
             token_set=TokenSet(access_token=access_token),
-            identity_data=IdentityData(
-                client_id=client_id,
-                email=email,
-            ),
+            identity_data=identity_data,
         )
 
     return _helper

--- a/jobbergate-cli/tests/subapps/job_submissions/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_app.py
@@ -71,9 +71,11 @@ def test_list_all__renders_paginated_results(
     dummy_context,
     cli_runner,
     mocker,
+    attach_persona,
 ):
     test_app = make_test_app("list-all", list_all)
     mocked_pagination = mocker.patch("jobbergate_cli.subapps.job_submissions.app.handle_pagination")
+    attach_persona("dummy@dummy.com")
     result = cli_runner.invoke(test_app, ["list-all"])
     assert result.exit_code == 0, f"list-all failed: {result.stdout}"
     mocked_pagination.assert_called_once_with(
@@ -84,6 +86,8 @@ def test_list_all__renders_paginated_results(
         title="Job Submission List",
         style_mapper=style_mapper,
         hidden_fields=HIDDEN_FIELDS,
+        nested_response_model_cls=JobSubmissionResponse,
+        value_mappers=None,
     )
 
 
@@ -104,7 +108,9 @@ def test_get_one__success(
     mocker,
     flag_id,
     separator,
+    attach_persona,
 ):
+    attach_persona("dummy@dummy.com")
     respx_mock.get(f"{dummy_domain}/jobbergate/job-submissions/1").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
@@ -120,6 +126,7 @@ def test_get_one__success(
         JobSubmissionResponse(**dummy_job_submission_data[0]),
         title="Job Submission",
         hidden_fields=HIDDEN_FIELDS,
+        value_mappers=None,
     )
 
 

--- a/jobbergate-cli/tests/subapps/test_pagination.py
+++ b/jobbergate-cli/tests/subapps/test_pagination.py
@@ -32,6 +32,7 @@ def test_handle_pagination__one_page(respx_mock, dummy_domain, dummy_context, du
         title="Applications List",
         style_mapper=None,
         hidden_fields=None,
+        value_mappers=None,
     )
 
 
@@ -71,6 +72,7 @@ def test_handle_pagination__show_next_page(respx_mock, dummy_domain, dummy_conte
         title="Applications List",
         style_mapper=None,
         hidden_fields=None,
+        value_mappers=None,
     )
     assert mock_render_paginated.call_args_list[1] == mocker.call(
         dummy_context,
@@ -78,6 +80,7 @@ def test_handle_pagination__show_next_page(respx_mock, dummy_domain, dummy_conte
         title="Applications List",
         style_mapper=None,
         hidden_fields=None,
+        value_mappers=None,
     )
 
 
@@ -123,6 +126,7 @@ def test_handle_pagination__show_previous_page(
         title="Applications List",
         style_mapper=None,
         hidden_fields=None,
+        value_mappers=None,
     )
     assert mock_render_paginated.call_args_list[1] == mocker.call(
         dummy_context,
@@ -130,6 +134,7 @@ def test_handle_pagination__show_previous_page(
         title="Applications List",
         style_mapper=None,
         hidden_fields=None,
+        value_mappers=None,
     )
     assert mock_render_paginated.call_args_list[2] == mocker.call(
         dummy_context,
@@ -137,4 +142,5 @@ def test_handle_pagination__show_previous_page(
         title="Applications List",
         style_mapper=None,
         hidden_fields=None,
+        value_mappers=None,
     )

--- a/jobbergate-cli/tests/test_schemas.py
+++ b/jobbergate-cli/tests/test_schemas.py
@@ -1,0 +1,70 @@
+from typing import Any, Dict, Optional, TypeVar
+
+from pydantic import BaseModel
+
+from jobbergate_cli.schemas import ListResponseEnvelope
+
+
+EnvelopeT = TypeVar("EnvelopeT")
+
+
+def test_list_response_envelope_with_plain_dict():
+    data = dict(
+        items=[
+            dict(name="item-1"),
+            dict(name="item-2"),
+        ],
+        total=2,
+        page=0,
+        size=5,
+        pages=1,
+    )
+    envelope: ListResponseEnvelope[Dict[str, Any]] = ListResponseEnvelope[Dict[str, Any]](**data)
+    assert envelope.items == [
+        dict(name="item-1"),
+        dict(name="item-2"),
+    ]
+    assert envelope.total == 2
+    assert envelope.page == 0
+    assert envelope.size == 5
+    assert envelope.pages == 1
+
+
+def test_list_envelope_with_nested_model():
+    data = dict(
+        items=[
+            dict(name="item-1"),
+            dict(name="item-2"),
+        ],
+        total=2,
+        page=0,
+        size=5,
+        pages=1,
+    )
+
+    class DummyModel(BaseModel):
+        name: str
+
+    dummy_envelope: ListResponseEnvelope[DummyModel] = ListResponseEnvelope[DummyModel](**data)
+    assert dummy_envelope.items == [
+        DummyModel(name="item-1"),
+        DummyModel(name="item-2"),
+    ]
+    assert dummy_envelope.total == 2
+    assert dummy_envelope.page == 0
+    assert dummy_envelope.size == 5
+    assert dummy_envelope.pages == 1
+
+    class IdiotModel(BaseModel):
+        name: str
+        foo: Optional[str] = None
+
+    idiot_envelope: ListResponseEnvelope[IdiotModel] = ListResponseEnvelope[IdiotModel](**data)
+    assert idiot_envelope.items == [
+        IdiotModel(name="item-1"),
+        IdiotModel(name="item-2"),
+    ]
+    assert idiot_envelope.total == 2
+    assert idiot_envelope.page == 0
+    assert idiot_envelope.size == 5
+    assert idiot_envelope.pages == 1


### PR DESCRIPTION
* Now, the user will see "cluster_name" when they view job_submissions instead of "client_id"
* When run in "multi-tenancy" mode, the organization_id is removed from the cluster_name when rendered
