### PR TITLE
[PENG-2059] Investigate and fix slow Jobbergate queries

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -4,11 +4,14 @@ This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
 
+- Fixed performance issue with the list endpoints dispatching additional select queries [PENG-2059]
 
 ## 4.3.0a2 -- 2024-01-29
+
 - Added clone capability to templates and job scripts [ASP-3335]
 
 ## 4.3.0a1 -- 2024-01-24
+
 ## 4.3.0a0 -- 2024-01-15
 
 - Improved error handling and reporting [ASP-4095]

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/models.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/models.py
@@ -73,11 +73,7 @@ class JobScript(CrudMixin, Base):
         """
         Include custom options on a query to eager load parent data.
         """
-        return query.options(
-            selectinload(cls.template).load_only(
-                JobScriptTemplateModel.id, JobScriptTemplateModel.identifier, JobScriptTemplateModel.name
-            )
-        )
+        return query.options(selectinload(cls.template).defer(JobScriptTemplateModel.template_vars))
 
 
 class JobScriptFile(FileMixin, Base):

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
@@ -93,4 +93,6 @@ class JobSubmission(CrudMixin, Base):
         """
         Include custom options on a query to eager load parent data.
         """
-        return query.options(selectinload(cls.job_script).load_only(JobScriptModel.id, JobScriptModel.name))
+        return query.options(
+            selectinload(cls.job_script).load_only(JobScriptModel.id, JobScriptModel.name, raiseload=True)
+        )

--- a/jobbergate-api/jobbergate_api/config.py
+++ b/jobbergate-api/jobbergate_api/config.py
@@ -16,6 +16,7 @@ class LogLevelEnum(str, Enum):
     Provide an enumeration class describing the available log levels.
     """
 
+    TRACE = "TRACE"
     DEBUG = "DEBUG"
     INFO = "INFO"
     WARNING = "WARNING"

--- a/jobbergate-api/jobbergate_api/storage.py
+++ b/jobbergate-api/jobbergate_api/storage.py
@@ -21,7 +21,7 @@ from sqlalchemy.sql.expression import Case, ColumnElement, UnaryExpression
 from starlette import status
 from yarl import URL
 
-from jobbergate_api.config import settings
+from jobbergate_api.config import LogLevelEnum, settings
 from jobbergate_api.security import IdentityPayload, PermissionMode, lockdown_with_identity
 
 INTEGRITY_CHECK_EXCEPTIONS = (UniqueViolationError,)
@@ -100,6 +100,8 @@ class EngineFactory:
                 pool_size=settings.DATABASE_POOL_SIZE,
                 pool_pre_ping=settings.DATABASE_POOL_PRE_PING,
                 max_overflow=settings.DATABASE_POOL_MAX_OVERFLOW,
+                logging_name="sqlalchemy.engine",
+                echo=settings.LOG_LEVEL == LogLevelEnum.TRACE,
             )
         return self.engine_map[db_url]
 


### PR DESCRIPTION
#### What
Some queries in Jobbergate that are generated from frontend requests are resulting in slowness including N+1 queries.

#### Why
Pydantic was bypassing `lazy="raise"` and dispatching additional selects when requested to list entries with their parent info. The investigation discovered that `load_only` allowed that, and `raiseload=True` can be used in this case to ensure that any additional query in the background raises an error on the unit tests.

`Task`: https://app.clickup.com/t/18022949/PENG-2059

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
