### PR TITLE
Fix issue with list job-submissions with parent data

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -4,8 +4,10 @@ This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
 
+- Fixed issue with list job-submissions with parent data created on previous prerelease [PENG-2059]
 
 ## 4.3.0a3 -- 2024-01-31
+
 - Fixed performance issue with the list endpoints dispatching additional select queries [PENG-2059]
 
 ## 4.3.0a2 -- 2024-01-29

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
@@ -93,6 +93,4 @@ class JobSubmission(CrudMixin, Base):
         """
         Include custom options on a query to eager load parent data.
         """
-        return query.options(
-            selectinload(cls.job_script).load_only(JobScriptModel.id, JobScriptModel.name, raiseload=True)
-        )
+        return query.options(selectinload(cls.job_script))


### PR DESCRIPTION
Fix list job-submissions with parent data, after recent changes from PR #465, that was resulting in an error on the API and consequently integration issues with the UI.