### PR TITLE
[ASP-3984] Add status badges for test coverage on Jobbergate

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -31,6 +31,17 @@ jobs:
           poetry env use "3.8"
           make qa
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          working-directory: jobbergate-core
+          flags: core
+          env_vars: OS,PYTHON
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: tests/coverage.xml
+          disable_search: true
+          fail_ci_if_error: true
+
   api-tests:
     name: "jobbergate-api tests"
     runs-on: "ubuntu-20.04"
@@ -40,6 +51,17 @@ jobs:
       - name: Run QA
         working-directory: ./jobbergate-composed
         run: docker-compose build jobbergate-api-qa && docker-compose run --rm jobbergate-api-qa
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          working-directory: jobbergate-api
+          flags: api
+          env_vars: OS,PYTHON
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: tests/coverage.xml
+          disable_search: true
+          fail_ci_if_error: true
 
   cli-tests:
     name: "jobbergate-cli tests"
@@ -64,6 +86,17 @@ jobs:
           poetry env use "3.8"
           make qa
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          working-directory: jobbergate-cli
+          flags: cli
+          env_vars: OS,PYTHON
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: tests/coverage.xml
+          disable_search: true
+          fail_ci_if_error: true
+
   agent-tests:
     name: "jobbergate-agent tests"
     runs-on: "ubuntu-20.04"
@@ -86,3 +119,14 @@ jobs:
         run: |
           poetry env use "3.8"
           make qa
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          working-directory: jobbergate-agent
+          flags: agent
+          env_vars: OS,PYTHON
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: tests/coverage.xml
+          disable_search: true
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 ![Build Status](https://img.shields.io/github/actions/workflow/status/omnivector-solutions/jobbergate/test_on_push.yaml?branch=main&label=main-build&logo=github&style=plastic)
+[![codecov](https://codecov.io/gh/omnivector-solutions/jobbergate/graph/badge.svg?token=Z0DGK5562T)](https://codecov.io/gh/omnivector-solutions/jobbergate)
 ![GitHub Issues](https://img.shields.io/github/issues/omnivector-solutions/jobbergate?label=issues&logo=github&style=plastic)
 ![Pull Requests](https://img.shields.io/github/issues-pr/omnivector-solutions/jobbergate?label=pull-requests&logo=github&style=plastic)
 ![GitHub Contributors](https://img.shields.io/github/contributors/omnivector-solutions/jobbergate?logo=github&style=plastic)
-
 
 > An [Omnivector](https://www.omnivector.io/) initiative
 >
 > [![omnivector-logo](https://omnivector-public-assets.s3.us-west-2.amazonaws.com/branding/omnivector-logo-text-black-horz.png)](https://www.omnivector.io/)
 
 # Jobbergate
-
 
 Jobbergate is a job templating and submission system that integrates with Slurm to
 enable the re-use and remote submission of job scripts to a Slurm cluster.
@@ -19,7 +18,6 @@ repository:
 
 * [jobbergate-api](https://github.com/omnivector-solutions/jobbergate/jobbergate-api)
 * [jobbergate-cli](https://github.com/omnivector-solutions/jobbergate/jobbergate-cli)
-
 
 The complete documentation for Jobbergate can be viewed at the
 [Jobbergate Documentation](https://omnivector-solutions.github.io/jobbergate/) site.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+      - type: patch
+        target: 90%

--- a/jobbergate-agent/poetry.lock
+++ b/jobbergate-agent/poetry.lock
@@ -581,7 +581,7 @@ colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "jobbergate-core"
-version = "4.3.0a2"
+version = "4.3.0a5"
 description = "Jobbergate Core"
 category = "main"
 optional = false
@@ -1002,14 +1002,14 @@ testing = ["coverage (==6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "3.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
-    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]
@@ -1448,4 +1448,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "c9def3e3d74e3f06a10d268e3e6d6e6e301d3c0aa1f20db13ac0f133c28c2262"
+content-hash = "333006a82b14b35f0d8bf0cff9c9d29800a2cf0a443514c5c3625c17da1b3589"

--- a/jobbergate-agent/pyproject.toml
+++ b/jobbergate-agent/pyproject.toml
@@ -62,7 +62,7 @@ freezegun = "^1.2.2"
 isort = "^5.9.3"
 mypy = "^0.931"
 pytest-asyncio = "^0.18.2"
-pytest-cov = "^3.0.0"
+pytest-cov = "^4.0.0"
 pytest-env = "^0.6.2"
 pytest-mock = "^3.7.0"
 pytest-random-order = "^1.0.4"
@@ -75,8 +75,7 @@ asyncio_mode = "auto"
 addopts = [
     "--random-order",
     "--cov=jobbergate_agent",
-    "--cov-report=term-missing",
-    "--cov-fail-under=90",
+    "--cov-report=xml:tests/coverage.xml",
 ]
 env = [
     "JOBBERGATE_AGENT_OIDC_DOMAIN = auth.com",
@@ -84,6 +83,10 @@ env = [
     "JOBBERGATE_AGENT_OIDC_CLIENT_SECRET = DUMMY-TEST-CLIENT-SECRET",
     "JOBBERGATE_AGENT_SLURMRESTD_JWT_KEY_STRING = DUMMY-JWT-SECRET",
 ]
+
+[tool.coverage.report]
+fail_under = 90
+show_missing = true
 
 [tool.black]
 line-length = 120

--- a/jobbergate-api/poetry.lock
+++ b/jobbergate-api/poetry.lock
@@ -4144,4 +4144,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "49d4ecb35cc664780816d89d74c0bac0980aba635db31c6dfdfd343e6f77723f"
+content-hash = "f288b95c6b84ed677efe8e907cbead3a9fcbf4e122dcdce19124d1213ea23bb8"

--- a/jobbergate-api/pyproject.toml
+++ b/jobbergate-api/pyproject.toml
@@ -50,7 +50,6 @@ auto-name-enum = "^2.0.0"
 [tool.poetry.group.dev.dependencies]
 asgi-lifespan = "^1.0.1"
 black = "^23"
-coverage = { extras = ["toml"], version = "^7.2.7" }
 flake8-docstrings = "^1.6.0"
 ipython = "^7.31.1"
 isort = "^5.9.3"
@@ -93,8 +92,12 @@ ignore = "W503,D200,D106,D402"
 
 
 [tool.pytest.ini_options]
-minversion = "6.0"
-addopts = ["--random-order", "--cov=jobbergate_api"]
+minversion = "7.0"
+addopts = [
+    "--random-order",
+    "--cov=jobbergate_api",
+    "--cov-report=xml:tests/coverage.xml",
+]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 env = [
@@ -114,9 +117,6 @@ concurrency = ["greenlet", "thread"]
 [tool.coverage.report]
 fail_under = 90
 show_missing = true
-
-[tool.coverage.html]
-show_contexts = true
 
 [tool.mypy]
 plugins = ["pydantic.mypy", "sqlalchemy.ext.mypy.plugin"]

--- a/jobbergate-cli/pyproject.toml
+++ b/jobbergate-cli/pyproject.toml
@@ -60,8 +60,7 @@ minversion = "7.0"
 addopts = [
     "--random-order",
     "--cov=jobbergate_cli",
-    "--cov-report=term-missing",
-    "--cov-fail-under=85",
+    "--cov-report=xml:tests/coverage.xml",
 ]
 env = [
     "ARMADA_API_BASE = https://some-pretend-armada-url.com",
@@ -70,8 +69,12 @@ env = [
     "OIDC_DOMAIN = dummy_auth_domain.com",
     "OIDC_AUDIENCE = https://dummy_auth_audience.com",
     "OIDC_CLIENT_ID = dummy_client_id",
-    "MULTI_TENANCY_ENABLED = false"
+    "MULTI_TENANCY_ENABLED = false",
 ]
+
+[tool.coverage.report]
+fail_under = 85
+show_missing = true
 
 [tool.black]
 line-length = 120

--- a/jobbergate-core/pyproject.toml
+++ b/jobbergate-core/pyproject.toml
@@ -47,9 +47,12 @@ minversion = "6.0"
 addopts = [
     "--random-order",
     "--cov=jobbergate_core",
-    "--cov-report=term-missing",
-    "--cov-fail-under=85",
+    "--cov-report=xml:tests/coverage.xml",
 ]
+
+[tool.coverage.report]
+fail_under = 85
+show_missing = true
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
#### What
* Setup Jobbergate to export test coverage reports to [codecov](https://about.codecov.io).
* Add new status badge to the repo: [![codecov](https://codecov.io/gh/omnivector-solutions/jobbergate/graph/badge.svg?token=Z0DGK5562T)](https://codecov.io/gh/omnivector-solutions/jobbergate)

#### Why
As a Jobbergate maintainer, I want to add a test coverage status badge to Jobbergate's repository. This will allow stakeholders, project contributors, and end-users to easily see the project's test coverage.

`Task`: https://jira.scania.com/browse/ASP-3984

#### References

* Using flags to manage mono-repos in codecov: https://docs.codecov.com/docs/flags
* Easily upload coverage reports to Codecov from GitHub Actions: https://github.com/codecov/codecov-action

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
