### PR TITLE
[ASP-4332] Verify jobbergate apps on v4

### DIFF
--- a/jobbergate-api/tests/apps/job_scripts/conftest.py
+++ b/jobbergate-api/tests/apps/job_scripts/conftest.py
@@ -15,7 +15,6 @@ def param_dict():
         "jobbergate_config": {
             "default_template": "test_job_script.sh",
             "job_name": "rats",
-            "output_directory": ".",
             "partition": "debug",
             "supporting_files": ["test_job_script.sh"],
             "supporting_files_output_name": {"test_job_script.sh": ["support_file_b.py"]},
@@ -33,7 +32,6 @@ def param_dict_flat():
         "job_name": "rats",
         "partitions": ["debug", "partition1"],
         "default_template": "test_job_script.sh",
-        "output_directory": ".",
         "partition": "debug",
         "supporting_files": ["test_job_script.sh"],
         "supporting_files_output_name": {"test_job_script.sh": ["support_file_b.py"]},

--- a/jobbergate-api/tests/conftest.py
+++ b/jobbergate-api/tests/conftest.py
@@ -1,4 +1,5 @@
 """Configuration of pytest."""
+
 import asyncio
 import contextlib
 import dataclasses
@@ -304,7 +305,6 @@ def dummy_application_config() -> str:
                 - partition1
         jobbergate_config:
             default_template: test_job_script.sh
-            output_directory: .
             supporting_files:
                 - test_job_script.sh
             supporting_files_output_name:

--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -5,6 +5,8 @@ This file keeps track of all notable changes to jobbergate-cli
 ## Unreleased
 
 - Removed `output_directory` from the schema `JobbergateConfig` for backward compatibility with jobbergate-legacy [ASP-4322]
+- Fixed bug on `jobbergate_cli.subapps.applications.application_helpers.get_running_jobs` when squeue finds no job [ASP-4322]
+- Fixed bug on `jobbergate application update` to pull the correct entry when the identifier is updated
 
 ## 4.4.0a1 -- 2024-02-21
 

--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,8 +4,10 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 
+- Removed `output_directory` from the schema `JobbergateConfig` for backward compatibility with jobbergate-legacy [ASP-4322]
 
 ## 4.4.0a1 -- 2024-02-21
+
 - Modified the Question/Answer workflow to make it behave like jobbergate-legacy [ASP-4332]
 
 ## 4.4.0a0 -- 2024-02-19

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -71,7 +71,6 @@ class JobbergateConfig(pydantic.BaseModel, extra=pydantic.Extra.allow):
 
     template_files: Optional[List[Path]]
     default_template: Optional[str] = None
-    output_directory: Path = Path(".")
     supporting_files_output_name: Optional[Dict[str, List[str]]] = None
     supporting_files: Optional[List[str]] = None
 

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/app.py
@@ -303,6 +303,9 @@ def update(
         )
         raise e
     finally:
+        if not id and update_identifier:
+            # We need to fetch from new identifier if it was updated
+            identifier = update_identifier
         result = fetch_application_data(jg_ctx, id=id, identifier=identifier)
 
         render_single_result(

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/application_helpers.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/application_helpers.py
@@ -22,7 +22,7 @@ def get_running_jobs(user_only=True):
     try:
         cmd_results = subprocess.run(cmd_args, capture_output=True, check=True)
         # Skip last line (empty), strip quotation marks
-        output_lines = cmd_results.stdout.decode("utf-8").strip().split("\n")[:-1]
+        output_lines = cmd_results.stdout.decode("utf-8").split("\n")[:-1]
         ID_alternatives = [ln.replace('"', "").strip() for ln in output_lines]
     except Exception:
         print("Could not retrieve queue information from SLURM.")

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/application_helpers.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/application_helpers.py
@@ -1,6 +1,7 @@
 """
 Helper functions that may be used inside of Jobbergate applications.
 """
+
 import fnmatch
 import re
 import shlex
@@ -21,7 +22,7 @@ def get_running_jobs(user_only=True):
     try:
         cmd_results = subprocess.run(cmd_args, capture_output=True, check=True)
         # Skip last line (empty), strip quotation marks
-        output_lines = cmd_results.stdout.decode("utf-8").strip().split("\n")
+        output_lines = cmd_results.stdout.decode("utf-8").strip().split("\n")[:-1]
         ID_alternatives = [ln.replace('"', "").strip() for ln in output_lines]
     except Exception:
         print("Could not retrieve queue information from SLURM.")

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
@@ -466,6 +466,7 @@ class ApplicationRuntime:
 
     def _gather_answers(self):
         """Gather the parameter values by executing the application methods."""
+        logger.debug("Gathering answers from the application")
         self.answers.update(self.supplied_params)
         # config should be self.answers ideally
         # but we use self.app_module.jobbergate_config for backward compatibility with v1
@@ -476,7 +477,7 @@ class ApplicationRuntime:
 
         while next_method is not None:
             method_to_call = getattr(self.app_module, next_method)
-
+            logger.debug(f"Calling method {next_method}")
             try:
                 workflow_questions = method_to_call(data=config)
             except NotImplementedError:
@@ -484,7 +485,7 @@ class ApplicationRuntime:
                     f"""
                     Abstract method not implemented.
 
-                    Please implement {method_to_call.__name__} in your class.",
+                    Please implement {next_method} in your class.",
                     """,
                     subject="Invalid application module",
                 )
@@ -508,6 +509,9 @@ class ApplicationRuntime:
 
             workflow_answers = cast(Dict[str, Any], inquirer.prompt(prompts, raise_keyboard_interrupt=True))
             workflow_answers.update(auto_answers)
+
+            logger.debug(f"Answers gathered from {next_method}: {workflow_answers}")
+
             config.update(workflow_answers)
             self.answers.update(workflow_answers)
             if len(auto_answers) > 0:
@@ -520,6 +524,7 @@ class ApplicationRuntime:
             application_config=dict(self.app_module.application_config),
             jobbergate_config=JobbergateConfig.parse_obj(self.app_module.jobbergate_config),
         )
+        logger.debug(f"Concluded getting answers: {self.answers}")
 
     def _update_template_files_information(self):
         """Update the information about the template files if not already present in the configuration."""

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
@@ -109,7 +109,7 @@ def get_template_output_name_mapping(config: JobbergateConfig, job_name: str) ->
 
     This provides the mapping as expected by the API v4 from the configuration on CLI v3.
     """
-    output_dir = config.output_directory
+    output_dir = pathlib.Path(".")
 
     if not config.default_template:
         raise Abort(
@@ -186,6 +186,8 @@ def render_template(
     :param Dict[str, Any] parameters: The parameters to use for rendering the template.
     """
 
+    logger.debug("Rendering template file: {} with parameters={}", template_path, parameters)
+
     Abort.require_condition(template_path.is_file(), f"Template file {template_path} does not exist or is not a file")
 
     with open(template_path, "r") as f:
@@ -214,7 +216,7 @@ def render_template(
             )
 
     raise Abort(
-        f"Unable to render filename={template} with context={context}",
+        f"Unable to render filename={template}",
         subject="Unable to render jinja template",
         log_message=f"Unable to render filename={template} with context={context}",
     )
@@ -288,7 +290,7 @@ def render_job_script_locally(
         with open(output_path / new_filename, "w") as f:
             f.write(file_content)
 
-        logger.debug(f"Rendered template file {new_filename} to path {output_path}")
+        logger.debug("Rendered template file {} to: {}", template_file.filename, new_filename)
 
 
 def render_job_script(

--- a/jobbergate-cli/tests/subapps/applications/test_app.py
+++ b/jobbergate-cli/tests/subapps/applications/test_app.py
@@ -311,7 +311,7 @@ def test_update__success_by_identifier(
     mocked_upload = mocker.patch("jobbergate_cli.subapps.applications.app.upload_application")
     mocked_upload.return_value = True
 
-    get_route = respx_mock.get(f"{dummy_domain}/jobbergate/job-script-templates/{application_identifier}")
+    get_route = respx_mock.get(f"{dummy_domain}/jobbergate/job-script-templates/dummy-identifier")
     get_route.mock(
         return_value=httpx.Response(
             httpx.codes.OK,

--- a/jobbergate-cli/tests/subapps/applications/test_application_helpers.py
+++ b/jobbergate-cli/tests/subapps/applications/test_application_helpers.py
@@ -44,6 +44,19 @@ def test_get_running_jobs(mocker):
 
     mocked_run.reset_mock()
 
+    # squeue found no jobs
+    mocked_output.stdout = "".encode("utf-8")
+    mocked_run.return_value = mocked_output
+
+    assert get_running_jobs() == []
+    mocked_run.assert_called_once_with(
+        shlex.split("""squeue --format="%.8A %j" --noheader --user=dummy-user"""),
+        capture_output=True,
+        check=True,
+    )
+
+    mocked_run.reset_mock()
+
     get_running_jobs(user_only=False)
     mocked_run.assert_called_once_with(
         shlex.split("""squeue --format="%.8A %j" --noheader"""),

--- a/jobbergate-cli/tests/subapps/applications/test_tools.py
+++ b/jobbergate-cli/tests/subapps/applications/test_tools.py
@@ -246,7 +246,6 @@ def test_load_application_from_source__success(dummy_module_source, dummy_jobber
     assert application.jobbergate_config == dict(
         default_template="job-script-template.py.j2",
         template_files=[pathlib.Path("job-script-template.py.j2")],
-        output_directory=pathlib.Path("."),
         supporting_files=None,
         supporting_files_output_name=None,
         user_supplied_key="user-supplied-value",
@@ -441,7 +440,6 @@ class TestApplicationRuntime:
         actual_result = application_runtime.as_flatten_param_dict()
         expected_result = {
             "template_files": None,
-            "output_directory": pathlib.PosixPath("."),
             "supporting_files_output_name": None,
             "supporting_files": None,
             "default_template": "test-job-script.py.j2",

--- a/jobbergate-cli/tests/subapps/conftest.py
+++ b/jobbergate-cli/tests/subapps/conftest.py
@@ -243,7 +243,6 @@ def dummy_config_source():
           default_template: job-script-template.py.j2
           template_files:
             - job-script-template.py.j2
-          output_directory: .
           supporting_files_output_name:
           supporting_files:
           user_supplied_key: user-supplied-value

--- a/jobbergate-cli/tests/subapps/job_scripts/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_app.py
@@ -301,7 +301,6 @@ def test_render__non_fast_mode_and_job_submission(
                     "baz": "BAZ",
                     "template_files": None,
                     "default_template": "test-job-script.py.j2",
-                    "output_directory": ".",
                     "supporting_files_output_name": None,
                     "supporting_files": None,
                 }
@@ -419,7 +418,6 @@ def test_render__with_fast_mode_and_no_job_submission(
                     "baz": "zab",
                     "template_files": None,
                     "default_template": "test-job-script.py.j2",
-                    "output_directory": ".",
                     "supporting_files_output_name": None,
                     "supporting_files": None,
                 }

--- a/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
@@ -708,7 +708,6 @@ class TestGetTemplateOutputNameMapping:
     def test_default_template_valid_output_name(self):
         config = JobbergateConfig(
             default_template="templates/template.j2",
-            output_directory=pathlib.Path("."),
             supporting_files=None,
             supporting_files_output_name=None,
         )
@@ -719,7 +718,6 @@ class TestGetTemplateOutputNameMapping:
     def test_default_template_valid_output_name__legacy_mode(self, tweak_settings):
         config = JobbergateConfig(
             default_template="templates/template.j2",
-            output_directory=pathlib.Path("."),
             supporting_files=None,
             supporting_files_output_name=None,
         )
@@ -732,7 +730,6 @@ class TestGetTemplateOutputNameMapping:
         config = JobbergateConfig(
             template_files=[pathlib.Path("templates/template1.j2"), pathlib.Path("templates/template2.j2")],
             default_template="templates/template1.j2",
-            output_directory=pathlib.Path("."),
             supporting_files=["templates/support1.j2", "templates/support2.j2"],
             supporting_files_output_name={
                 "templates/support1.j2": ["output1.txt"],
@@ -747,7 +744,6 @@ class TestGetTemplateOutputNameMapping:
     def test_default_template_not_specified(self):
         config = JobbergateConfig(
             template_files=[],
-            output_directory=pathlib.Path("."),
             supporting_files_output_name=None,
             supporting_files=None,
         )


### PR DESCRIPTION
#### What
* Removed `output_directory` from `JobbergateConfig` schemas
  * There is no mention of it on jobbergate-legacy
  * It was unexpectedly triggering logical blocks on legacy Jinja templates
* Fixed `get_running_jobs`
  * It was return a list with an empty string `['']` when squeue found no jobs
* Fixed bug on `jobbergate application update` to pull the correct entry when the identifier is updated

#### Why
Explain why the proposed change is necessary.

`Task`: https://jira.scania.com/browse/ASP-4332

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
