### PR TITLE
Revert "PENG-2039 Bumped minor version and updated CHANGELOGs"

### DIFF
--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -4,11 +4,10 @@ This file keeps track of all notable changes to jobbergate-core
 
 ## Unreleased
 
-
-## 4.5.0a2 -- 2024-02-23
-## 4.5.0a1 -- 2024-02-22
 ## 4.4.0a1 -- 2024-02-21
+
 ## 4.4.0a0 -- 2024-02-19
+
 ## 4.3.0 -- 2024-02-14
 
 - Revamped job_submissions statuses and tracked more details slurm job_state [PENG-2064]

--- a/jobbergate-agent/pyproject.toml
+++ b/jobbergate-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jobbergate-agent"
-version = "4.5.0a2"
+version = "4.4.0a1"
 description = "Jobbergate Agent"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -6,12 +6,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 - Pinned aio-pika dependency to avoid issues with opentelemetry [PENG-2111]
 - Downgrade FastAPI to 0.99.1 to patch issue on the file endpoints
-
-## 4.5.0a1 -- 2024-02-22
-
 - Added notifications via rabbitmq for job status updates [PENG-2039]
-
-## 4.4.0a1 -- 2024-02-21
 
 ## 4.4.0a0 -- 2024-02-19
 

--- a/jobbergate-api/pyproject.toml
+++ b/jobbergate-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jobbergate-api"
-version = "4.5.0a2"
+version = "4.4.0a1"
 description = "Jobbergate API"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"
@@ -105,16 +105,16 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 
 [tool.pytest_env]
-DEPLOY_ENV = "TEST"                         # Enforces that test database env vars will be used
-ARMASEC_DOMAIN = "armasec.dev"              # Must align with the rs256_domain fixture in armasec's pytest extension
-ARMASEC_DEBUG = false                       # Set this to True to debug armasec issues by seeing verbose logging
+DEPLOY_ENV = "TEST"                                              # Enforces that test database env vars will be used
+ARMASEC_DOMAIN = "armasec.dev"                                   # Must align with the rs256_domain fixture in armasec's pytest extension
+ARMASEC_DEBUG = false                                            # Set this to True to debug armasec issues by seeing verbose logging
 SENDGRID_FROM_EMAIL = "info@pytesting.com"
 SENDGRID_API_KEY = "test-api-key"
 AWS_ACCESS_KEY_ID = "compose-s3-key"
 AWS_SECRET_ACCESS_KEY = "compose-s3-secret"
-RABBITMQ_HOST = {value = "localhost", skip_if_set = true}
-RABBITMQ_USERNAME = {value = "local-user", skip_if_set = true}
-RABBITMQ_PASSWORD = {value = "local-pswd", skip_if_set = true}
+RABBITMQ_HOST = { value = "localhost", skip_if_set = true }
+RABBITMQ_USERNAME = { value = "local-user", skip_if_set = true }
+RABBITMQ_PASSWORD = { value = "local-pswd", skip_if_set = true }
 
 [tool.coverage.run]
 omit = ["jobbergate_api/main.py", "jobbergate_api/safe_types.py"]

--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -8,9 +8,6 @@ This file keeps track of all notable changes to jobbergate-cli
 - Fixed bug on `jobbergate_cli.subapps.applications.application_helpers.get_running_jobs` when squeue finds no job [ASP-4322]
 - Fixed bug on `jobbergate application update` to pull the correct entry when the identifier is updated
 
-## 4.5.0a2 -- 2024-02-23
-## 4.5.0a1 -- 2024-02-22
-
 ## 4.4.0a1 -- 2024-02-21
 
 - Modified the Question/Answer workflow to make it behave like jobbergate-legacy [ASP-4332]

--- a/jobbergate-cli/pyproject.toml
+++ b/jobbergate-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jobbergate-cli"
-version = "4.5.0a2"
+version = "4.4.0a1"
 description = "Jobbergate CLI Client"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/jobbergate-core/CHANGELOG.md
+++ b/jobbergate-core/CHANGELOG.md
@@ -4,11 +4,10 @@ This file keeps track of all notable changes to jobbergate-core
 
 ## Unreleased
 
-
-## 4.5.0a2 -- 2024-02-23
-## 4.5.0a1 -- 2024-02-22
 ## 4.4.0a1 -- 2024-02-21
+
 ## 4.4.0a0 -- 2024-02-19
+
 ## 4.3.0 -- 2024-02-14
 
 - Keep version in sync with the other components.

--- a/jobbergate-core/pyproject.toml
+++ b/jobbergate-core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jobbergate-core"
-version = "4.5.0a2"
+version = "4.4.0a1"
 description = "Jobbergate Core"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
Revert version bumped on a feature branch.

#### Why
Get the version number back on track.

**Notes**:

The pre-release `4.5.0a2` has been done with an unexpected version number, we need to keep on eye on it on the next release cycle, when we indeed work on `4.5`.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
