### PR TITLE
[ASP-4332] Verify Jobbergate apps using new Jobbergate

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 
+Fixed bug on `jobbergate_cli.subapps.applications.questions.Integer` when a default of zero could not be set properly
+
 ## 4.4.0 -- 2024-03-19
 
 - Removed `output_directory` from the schema `JobbergateConfig` for backward compatibility with jobbergate-legacy [ASP-4322]

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/questions.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/questions.py
@@ -100,6 +100,8 @@ class Integer(QuestionBase):
         super().__init__(variablename, message, **kwargs)
         self.minval = minval
         self.maxval = maxval
+        if self.inquirer_kwargs.get("default") == 0:
+            self.inquirer_kwargs["default"] = "0"
         self.inquirer_kwargs.update(validate=self._validator)
 
     def _validator(self, _, current):

--- a/jobbergate-cli/tests/subapps/applications/test_questions.py
+++ b/jobbergate-cli/tests/subapps/applications/test_questions.py
@@ -41,6 +41,24 @@ def test_Integer__success(dummy_render_class, mocker):
     assert answers["foo"] == 13
 
 
+def test_Integer__zero_as_default():
+    """
+    The default of zero is an eddy case for inquired.
+
+    Due to implementation details on inquire and the fact that its boolean equivalent
+    is false, `0` was not set as default and was not presented on the questions.
+
+    We need to ensure it is.
+    """
+    question = Integer("foo", "gimme the foo!", default=0)
+    prompts = question.make_prompts()
+
+    prompt = prompts.pop()
+
+    assert bool(prompt.default) is True
+    assert int(prompt.default) == 0
+
+
 def test_Integer__fails_with_outside_of_range(dummy_render_class, mocker):
     variablename = "foo"
     question = Integer(variablename, "gimme the foo!", minval=14, maxval=16)


### PR DESCRIPTION
#### What
Fix a bug when `0` is the default value for an `Integer` question.

#### Why
Since `bool(0) is False`, internal details on inquire just ignore it.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
