### PR TITLE
[ASP-4586] Submit jobs on behalf of other users with jobbergate-agent -- CLI

### DIFF
--- a/fake-sbatch/fake_sbatch/main.py
+++ b/fake-sbatch/fake_sbatch/main.py
@@ -16,8 +16,8 @@ def submit():
         raise typer.Exit(code=1)
 
     fake_slurm_job_id = randint(settings.FAKE_SBATCH_MIN_JOB_ID, settings.FAKE_SBATCH_MAX_JOB_ID)
-    typer.echo(f"fake-sbatch: Submitted batch job {fake_slurm_job_id}")
+    typer.echo(f"{fake_slurm_job_id},fake-sbatch-cluster")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app()

--- a/jobbergate-agent/jobbergate_agent/jobbergate/schemas.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/schemas.py
@@ -34,7 +34,7 @@ class PendingJobSubmission(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     name: str
     owner_email: str
     execution_directory: Optional[Path]
-    sbatch_parameters: List[str] = pydantic.Field(default_factory=list)
+    sbatch_arguments: List[str] = pydantic.Field(default_factory=list)
     job_script: JobScript
 
 

--- a/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
@@ -7,7 +7,7 @@ import pwd
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from buzz import DoExceptParams, require_condition
+from buzz import DoExceptParams
 from jobbergate_core.tools.sbatch import SubmissionHandler, inject_sbatch_params
 from loguru import logger
 
@@ -94,9 +94,9 @@ async def get_job_script_file(pending_job_submission: PendingJobSubmission, subm
 
     job_script = await retrieve_submission_file(job_script_file)
 
-    if pending_job_submission.sbatch_parameters:
+    if pending_job_submission.sbatch_arguments:
         job_script = inject_sbatch_params(
-            job_script, pending_job_submission.sbatch_parameters, "Sbatch params injected at submission time"
+            job_script, pending_job_submission.sbatch_arguments, "Sbatch params injected at submission time"
         )
 
     return await write_submission_file(job_script, job_script_file.filename, submit_dir)
@@ -183,6 +183,7 @@ async def submit_job_script(
     :param: pending_job_submission: A job_submission with fields needed to submit.
     :returns: The ``slurm_job_id`` for the submitted job
     """
+    logger.debug(f"Submitting {pending_job_submission}")
 
     async def _reject_handler(params: DoExceptParams):
         """
@@ -206,6 +207,13 @@ async def submit_job_script(
         preexec_fn = run_as_user(username)
 
     submit_dir = pending_job_submission.execution_directory or SETTINGS.DEFAULT_SLURM_WORK_DIR
+    async with handle_errors_async(
+        "The submission directory must exist and be an absolute path",
+        raise_exc_class=JobSubmissionError,
+        do_except=_reject_handler,
+    ):
+        if not (submit_dir.exists() and submit_dir.is_absolute()):
+            raise ValueError(submit_dir.as_posix())
 
     sbatch_handler = SubmissionHandler(
         sbatch_path=SETTINGS.SBATCH_PATH,
@@ -221,12 +229,6 @@ async def submit_job_script(
             do_except=_reject_handler,
         ):
             logger.debug(f"Processing submission files for job submission {pending_job_submission.id}")
-
-            require_condition(
-                expr=submit_dir.exists() and submit_dir.is_absolute(),
-                message=f"The submission directory must exist and be an absolute path, got: {submit_dir.as_posix()}",
-                raise_exc_class=JobSubmissionError,
-            )
 
             supporting_files = await process_supporting_files(pending_job_submission, tmp_dir_path)
 

--- a/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from buzz import DoExceptParams, require_condition
-from jobbergate_core.tools.sbatch import SbatchHandler, inject_sbatch_params
+from jobbergate_core.tools.sbatch import SubmissionHandler, inject_sbatch_params
 from loguru import logger
 
 from jobbergate_agent.clients.cluster_api import backend_client as jobbergate_api_client
@@ -207,9 +207,8 @@ async def submit_job_script(
 
     submit_dir = pending_job_submission.execution_directory or SETTINGS.DEFAULT_SLURM_WORK_DIR
 
-    sbatch_handler = SbatchHandler(
+    sbatch_handler = SubmissionHandler(
         sbatch_path=SETTINGS.SBATCH_PATH,
-        scontrol_path=SETTINGS.SCONTROL_PATH,
         submission_directory=submit_dir,
         preexec_fn=preexec_fn,
     )

--- a/jobbergate-agent/jobbergate_agent/jobbergate/update.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/update.py
@@ -1,7 +1,7 @@
 import json
 from typing import List
 
-from jobbergate_core.tools.sbatch import SbatchHandler
+from jobbergate_core.tools.sbatch import InfoHandler
 from loguru import logger
 
 from jobbergate_agent.clients.cluster_api import backend_client as jobbergate_api_client
@@ -11,11 +11,11 @@ from jobbergate_agent.utils.exception import JobbergateApiError, SbatchError
 from jobbergate_agent.utils.logging import log_error
 
 
-async def fetch_job_data(slurm_job_id: int, sbatch_handler: SbatchHandler) -> SlurmJobData:
+async def fetch_job_data(slurm_job_id: int, info_handler: InfoHandler) -> SlurmJobData:
     logger.debug(f"Fetching slurm job status for slurm job {slurm_job_id}")
 
     try:
-        data = sbatch_handler.get_job_info(slurm_job_id)
+        data = info_handler.get_job_info(slurm_job_id)
     except RuntimeError as e:
         logger.error(f"Failed to fetch job state from slurm: {e}")
         return SlurmJobData(
@@ -76,11 +76,7 @@ async def update_active_jobs():
     """
     logger.debug("Started updating slurm job data for active jobs...")
 
-    sbatch_handler = SbatchHandler(
-        sbatch_path=SETTINGS.SBATCH_PATH,
-        scontrol_path=SETTINGS.SCONTROL_PATH,
-        submission_directory=SETTINGS.DEFAULT_SLURM_WORK_DIR,
-    )
+    sbatch_handler = InfoHandler(scontrol_path=SETTINGS.SCONTROL_PATH)
 
     logger.debug("Fetching active jobs")
     active_job_submissions = await fetch_active_submissions()

--- a/jobbergate-agent/tests/jobbergate/test_submit.py
+++ b/jobbergate-agent/tests/jobbergate/test_submit.py
@@ -398,7 +398,7 @@ async def test_submit_job_script__success_with_files(
 
     mocked_sbatch = mock.MagicMock()
     mocked_sbatch.submit_job = lambda *args, **kwargs: 13
-    mocker.patch("jobbergate_agent.jobbergate.submit.SbatchHandler", return_value=mocked_sbatch)
+    mocker.patch("jobbergate_agent.jobbergate.submit.SubmissionHandler", return_value=mocked_sbatch)
 
     async with respx.mock:
         download_route = respx.get(f"{SETTINGS.BASE_API_URL}/jobbergate/job-scripts/1/upload/application.sh")
@@ -432,7 +432,7 @@ async def test_submit_job_script__success_without_files(
 
     mocked_sbatch = mock.MagicMock()
     mocked_sbatch.submit_job = lambda *args, **kwargs: 13
-    mocker.patch("jobbergate_agent.jobbergate.submit.SbatchHandler", return_value=mocked_sbatch)
+    mocker.patch("jobbergate_agent.jobbergate.submit.SubmissionHandler", return_value=mocked_sbatch)
 
     async with respx.mock:
         download_route = respx.get(f"{SETTINGS.BASE_API_URL}/jobbergate/job-scripts/1/upload/application.sh")
@@ -476,7 +476,7 @@ async def test_submit_job_script__with_non_default_execution_directory(
 
     mocked_sbatch = mock.MagicMock()
     mocked_sbatch.submit_job = lambda *args, **kwargs: 13
-    mocker.patch("jobbergate_agent.jobbergate.submit.SbatchHandler", return_value=mocked_sbatch)
+    mocker.patch("jobbergate_agent.jobbergate.submit.SubmissionHandler", return_value=mocked_sbatch)
 
     async with respx.mock:
         download_route = respx.get(f"{SETTINGS.BASE_API_URL}/jobbergate/job-scripts/1/upload/application.sh")
@@ -508,7 +508,7 @@ async def test_submit_job_script__raises_exception_if_no_executable_script_was_f
     mock_mark_as_rejected = mocker.patch("jobbergate_agent.jobbergate.submit.mark_as_rejected")
 
     mocked_sbatch = mock.MagicMock()
-    mocker.patch("jobbergate_agent.jobbergate.submit.SbatchHandler", return_value=mocked_sbatch)
+    mocker.patch("jobbergate_agent.jobbergate.submit.SubmissionHandler", return_value=mocked_sbatch)
 
     with pytest.raises(JobSubmissionError, match="Could not find an executable"):
         await submit_job_script(pending_job_submission, user_mapper)
@@ -535,7 +535,7 @@ async def test_submit_job_script__raises_exception_if_sbatch_fails(
 
     mocked_sbatch = mock.MagicMock()
     mocked_sbatch.submit_job.side_effect = RuntimeError("BOOM!")
-    mocker.patch("jobbergate_agent.jobbergate.submit.SbatchHandler", return_value=mocked_sbatch)
+    mocker.patch("jobbergate_agent.jobbergate.submit.SubmissionHandler", return_value=mocked_sbatch)
 
     async with respx.mock:
         respx.post(f"https://{SETTINGS.OIDC_DOMAIN}/oauth/token").mock(

--- a/jobbergate-agent/tests/jobbergate/test_submit.py
+++ b/jobbergate-agent/tests/jobbergate/test_submit.py
@@ -532,12 +532,12 @@ async def test_submit_job_script__raises_exception_if_execution_dir_does_not_exi
     mocked_sbatch = mock.MagicMock()
     mocker.patch("jobbergate_agent.jobbergate.submit.SubmissionHandler", return_value=mocked_sbatch)
 
-    with pytest.raises(JobSubmissionError, match="The submission directory must exist and be an absolute path"):
+    with pytest.raises(JobSubmissionError, match="The execution directory must exist and be an absolute path"):
         await submit_job_script(pending_job_submission, user_mapper)
 
     mock_mark_as_rejected.assert_called_once_with(
         dummy_pending_job_submission_data["id"],
-        RegexArgMatcher(".*The submission directory must exist and be an absolute path.*"),
+        RegexArgMatcher(".*The execution directory must exist and be an absolute path.*"),
     )
 
 
@@ -550,19 +550,18 @@ async def test_submit_job_script__raises_exception_if_execution_dir_is_relative(
 
     submit_dir = tmp_path / pending_job_submission.execution_directory
     submit_dir.mkdir()
-    assert submit_dir.is_dir()
 
     mock_mark_as_rejected = mocker.patch("jobbergate_agent.jobbergate.submit.mark_as_rejected")
 
     mocked_sbatch = mock.MagicMock()
     mocker.patch("jobbergate_agent.jobbergate.submit.SubmissionHandler", return_value=mocked_sbatch)
 
-    with pytest.raises(JobSubmissionError, match="The submission directory must exist and be an absolute path"):
+    with pytest.raises(JobSubmissionError, match="The execution directory must exist and be an absolute path"):
         await submit_job_script(pending_job_submission, user_mapper)
 
     mock_mark_as_rejected.assert_called_once_with(
         dummy_pending_job_submission_data["id"],
-        RegexArgMatcher(".*The submission directory must exist and be an absolute path.*"),
+        RegexArgMatcher(".*The execution directory must exist and be an absolute path.*"),
     )
 
 

--- a/jobbergate-agent/tests/jobbergate/test_update.py
+++ b/jobbergate-agent/tests/jobbergate/test_update.py
@@ -201,7 +201,7 @@ async def test_update_active_jobs(mocker):
     """
 
     mocked_sbatch = mock.MagicMock()
-    mocker.patch("jobbergate_agent.jobbergate.update.SbatchHandler", return_value=mocked_sbatch)
+    mocker.patch("jobbergate_agent.jobbergate.update.InfoHandler", return_value=mocked_sbatch)
 
     mocker.patch(
         "jobbergate_agent.jobbergate.update.fetch_active_submissions",

--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -8,6 +8,7 @@ This file keeps track of all notable changes to jobbergate-cli
 - Fixed bug on `jobbergate_cli.subapps.applications.application_helpers.get_running_jobs` when squeue finds no job [ASP-4322]
 - Fixed bug on `jobbergate application update` to pull the correct entry when the identifier is updated
 - Dropped support for Python 3.8 and 3.9
+- Added Jobbergate-core as a project dependency to reuse key components
 
 ## 4.5.0a2 -- 2024-02-23
 

--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -11,6 +11,7 @@ This file keeps track of all notable changes to jobbergate-cli
 - Added Jobbergate-core as a project dependency to reuse key components
 - Refactored on-site submission to use the new `jobbergate-core` components
 - Replaced `execution_parameters` by `sbatch_arguments` on job submission
+- Refactored `jobbergate_cli.subapps.job_submissions.tools.create_submission` into two classes in the same module to reduce complexity in the codebase
 
 ## 4.5.0a2 -- 2024-02-23
 

--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -9,6 +9,8 @@ This file keeps track of all notable changes to jobbergate-cli
 - Fixed bug on `jobbergate application update` to pull the correct entry when the identifier is updated
 - Dropped support for Python 3.8 and 3.9
 - Added Jobbergate-core as a project dependency to reuse key components
+- Refactored on-site submission to use the new `jobbergate-core` components
+- Replaced `execution_parameters` by `sbatch_arguments` on job submission
 
 ## 4.5.0a2 -- 2024-02-23
 

--- a/jobbergate-cli/Dockerfile
+++ b/jobbergate-cli/Dockerfile
@@ -6,10 +6,14 @@ RUN apt update && apt install -y curl libpq-dev gcc
 
 RUN curl -sSL  https://install.python-poetry.org | \
     POETRY_HOME=/opt/poetry POETRY_VERSION=1.5.1 python && \
-    cd /usr/local/bin && \
-    ln -s /opt/poetry/bin/poetry && \
+    ln -s /opt/poetry/bin/poetry /usr/local/bin/poetry && \
     poetry config virtualenvs.create false
 
 COPY ./pyproject.toml ./poetry.lock* ./README* ./LICENSE* /app/
-COPY ./jobbergate_cli /app/jobbergate_cli
-RUN poetry install --without=dev
+COPY ./etc/entrypoint.sh /app/entrypoint.sh
+WORKDIR /app
+
+VOLUME /app/jobbergate_cli
+VOLUME /jobbergate-core
+
+ENTRYPOINT /app/entrypoint.sh

--- a/jobbergate-cli/etc/entrypoint.sh
+++ b/jobbergate-cli/etc/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+cd /app
+poetry install --without=dev
+
+# Start a bash shell
+exec /bin/bash

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -96,6 +96,11 @@ class Settings(BaseSettings):
 
         return values
 
+    @property
+    def is_onsite_mode(self) -> bool:
+        """Check if the SBATCH_PATH is set, indicating that the CLI is running in on-site mode."""
+        return self.SBATCH_PATH is not None
+
     class Config:
         """
         Customize behavior of the Settings class. Especially, enable the use of dotenv to load settings from a ``.env``

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -237,7 +237,7 @@ class JobSubmissionResponse(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     created_at: Optional[datetime]
     updated_at: Optional[datetime]
     report_message: Optional[str]
-    execution_parameters: Optional[Dict[str, Any]]
+    sbatch_arguments: Optional[list[str]]
 
 
 class JobScriptCreateRequest(pydantic.BaseModel):
@@ -277,7 +277,7 @@ class JobSubmissionCreateRequestData(pydantic.BaseModel):
     slurm_job_id: Optional[int] = None
     client_id: Optional[str] = pydantic.Field(None, alias="cluster_name")
     execution_directory: Optional[Path] = None
-    execution_parameters: Dict[str, Any] = pydantic.Field(default_factory=dict)
+    sbatch_arguments: Optional[list[str]]
 
 
 EnvelopeT = TypeVar("EnvelopeT")

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -23,7 +23,7 @@ from jobbergate_cli.subapps.job_scripts.tools import (
     upload_job_script_files,
 )
 from jobbergate_cli.subapps.job_submissions.app import HIDDEN_FIELDS as JOB_SUBMISSION_HIDDEN_FIELDS
-from jobbergate_cli.subapps.job_submissions.tools import create_job_submission
+from jobbergate_cli.subapps.job_submissions.tools import job_submissions_factory
 from jobbergate_cli.subapps.pagination import handle_pagination
 from jobbergate_cli.text_tools import dedent
 
@@ -344,7 +344,7 @@ def render(
         actual_value=submit,
     )
 
-    if settings.SBATCH_PATH is None or not submit:
+    if settings.is_onsite_mode is False or not submit:
         # Notice on-site submission will download the job script files anyway, so it is asked just in remote mode.
         download = question_helper(
             question_func=typer.confirm,
@@ -361,7 +361,7 @@ def render(
         return
 
     try:
-        job_submission_result = create_job_submission(
+        submissions_handler = job_submissions_factory(
             jg_ctx=jg_ctx,
             job_script_id=job_script_result.job_script_id,
             name=job_script_result.name,
@@ -370,6 +370,7 @@ def render(
             execution_directory=execution_directory,
             sbatch_arguments=None,
         )
+        job_submission_result = submissions_handler.run()
     except Exception as err:
         raise Abort(
             "Failed to immediately submit the job after job script creation.",

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -368,7 +368,7 @@ def render(
             description=job_script_result.description,
             cluster_name=cluster_name,
             execution_directory=execution_directory,
-            execution_parameters_file=None,
+            sbatch_arguments=None,
         )
     except Exception as err:
         raise Abort(

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -376,9 +376,9 @@ def render(
             "Failed to immediately submit the job after job script creation.",
             subject="Automatic job submission failed",
             support=True,
-            log_message=f"""
-                There was an issue submitting the job immediately job_script_id={job_script_result.job_script_id}.
-            """,
+            log_message="There was an issue submitting the job immediately job_script_id={}".format(
+                job_script_result.job_script_id
+            ),
             original_error=err,
         )
 

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -21,12 +21,12 @@ from jobbergate_cli.subapps.pagination import handle_pagination
 HIDDEN_FIELDS = [
     "created_at",
     "execution_directory",
-    "execution_parameters",
     "is_archived",
     "job_script",
     "report_message",
-    "updated_at",
+    "sbatch_arguments",
     "slurm_job_info",
+    "updated_at",
 ]
 
 
@@ -71,17 +71,16 @@ def create(
             """
         ).strip(),
     ),
-    execution_parameters: Optional[Path] = typer.Option(
+    sbatch_arguments: Optional[list[str]] = typer.Option(
         None,
+        "--sbatch-arguments",
+        "-s",
         help=dedent(
             """
-            The path to a JSON file containing the parameters to be passed to the job submission.
-            See more details at: https://slurm.schedmd.com/rest_api.html
+            Additional arguments to pass as sbatch directives. These should be provided as a list of strings.
+            See more details at: https://slurm.schedmd.com/sbatch.html
             """
         ).strip(),
-        exists=True,
-        readable=True,
-        resolve_path=True,
     ),
     download: bool = typer.Option(
         False,
@@ -100,7 +99,7 @@ def create(
         description=description,
         execution_directory=execution_directory,
         cluster_name=cluster_name,
-        execution_parameters_file=execution_parameters,
+        sbatch_arguments=sbatch_arguments,
         download=download,
     )
 

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 import typer
 
 from jobbergate_cli.constants import SortOrder
-from jobbergate_cli.exceptions import handle_abort
+from jobbergate_cli.exceptions import Abort, handle_abort
 from jobbergate_cli.render import StyleMapper, render_single_result, terminal_message
 from jobbergate_cli.requests import make_request
 from jobbergate_cli.schemas import JobbergateContext, JobSubmissionResponse
@@ -92,17 +92,26 @@ def create(
     """
     jg_ctx: JobbergateContext = ctx.obj
 
-    submissions_handler = job_submissions_factory(
-        jg_ctx,
-        job_script_id,
-        name,
-        description=description,
-        execution_directory=execution_directory,
-        cluster_name=cluster_name,
-        sbatch_arguments=sbatch_arguments,
-        download=download,
-    )
-    result = submissions_handler.run()
+    try:
+        submissions_handler = job_submissions_factory(
+            jg_ctx,
+            job_script_id,
+            name,
+            description=description,
+            execution_directory=execution_directory,
+            cluster_name=cluster_name,
+            sbatch_arguments=sbatch_arguments,
+            download=download,
+        )
+        result = submissions_handler.run()
+    except Exception as err:
+        raise Abort(
+            "Failed to create the job submission",
+            subject="Job submission failed",
+            support=True,
+            log_message=f"There was an issue submitting the job from job_script_id={job_script_id}",
+            original_error=err,
+        )
 
     render_single_result(
         jg_ctx,

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -13,7 +13,7 @@ from jobbergate_cli.exceptions import handle_abort
 from jobbergate_cli.render import StyleMapper, render_single_result, terminal_message
 from jobbergate_cli.requests import make_request
 from jobbergate_cli.schemas import JobbergateContext, JobSubmissionResponse
-from jobbergate_cli.subapps.job_submissions.tools import create_job_submission, fetch_job_submission_data
+from jobbergate_cli.subapps.job_submissions.tools import fetch_job_submission_data, job_submissions_factory
 from jobbergate_cli.subapps.pagination import handle_pagination
 
 
@@ -92,7 +92,7 @@ def create(
     """
     jg_ctx: JobbergateContext = ctx.obj
 
-    result = create_job_submission(
+    submissions_handler = job_submissions_factory(
         jg_ctx,
         job_script_id,
         name,
@@ -102,6 +102,7 @@ def create(
         sbatch_arguments=sbatch_arguments,
         download=download,
     )
+    result = submissions_handler.run()
 
     render_single_result(
         jg_ctx,

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/tools.py
@@ -196,11 +196,38 @@ class OnsiteJobSubmission(JobSubmissionABC):
         return data
 
 
-def job_submissions_factory(*args, **kwargs) -> JobSubmissionABC:
+def job_submissions_factory(
+    jg_ctx: JobbergateContext,
+    job_script_id: int,
+    name: str,
+    execution_directory: Path | None = None,
+    cluster_name: str | None = None,
+    download: bool = False,
+    description: Optional[str] = None,
+    sbatch_arguments: Optional[list[str]] = None,
+) -> JobSubmissionABC:
     """Job submission factory function. Returns the correct job submission class based on the current mode."""
     if settings.is_onsite_mode:
-        return OnsiteJobSubmission(*args, **kwargs)
-    return RemoteJobSubmission(*args, **kwargs)
+        return OnsiteJobSubmission(
+            jg_ctx=jg_ctx,
+            job_script_id=job_script_id,
+            name=name,
+            execution_directory=execution_directory,
+            cluster_name=cluster_name,
+            download=download,
+            description=description,
+            sbatch_arguments=sbatch_arguments,
+        )
+    return RemoteJobSubmission(
+        jg_ctx=jg_ctx,
+        job_script_id=job_script_id,
+        name=name,
+        execution_directory=execution_directory,
+        cluster_name=cluster_name,
+        download=download,
+        description=description,
+        sbatch_arguments=sbatch_arguments,
+    )
 
 
 def fetch_job_submission_data(

--- a/jobbergate-cli/poetry.lock
+++ b/jobbergate-cli/poetry.lock
@@ -563,6 +563,27 @@ files = [
 ansicon = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "jobbergate-core"
+version = "4.5.0a2"
+description = "Jobbergate Core"
+optional = false
+python-versions = "^3.10"
+files = []
+develop = true
+
+[package.dependencies]
+httpx = "^0.24.1"
+loguru = "^0.6.0"
+pendulum = "3.0.0b1"
+py-buzz = "^4.0.0"
+pydantic = "^1.10.12"
+python-jose = "^3.3.0"
+
+[package.source]
+type = "directory"
+url = "../jobbergate-core"
+
+[[package]]
 name = "loguru"
 version = "0.6.0"
 description = "Python logging made (stupidly) simple"
@@ -1628,4 +1649,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "31428f5b138631a6b91e014041d0fea424231b9a1edb47aca7062f2e8c25eed2"
+content-hash = "885396e7482326630e7080670bc0b178693920eca7441c6f8641f4c899c132b3"

--- a/jobbergate-cli/pyproject.toml
+++ b/jobbergate-cli/pyproject.toml
@@ -21,18 +21,13 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
+jobbergate-core = { path = "../jobbergate-core", develop = true }
 click = "^8.1.0"
-httpx = "^0.24.1"
 importlib-metadata = "^4.2"
 inquirer = "^3.1.0"
 Jinja2 = "^3.1.2"
-loguru = "^0.6.0"
-pendulum = "3.0.0b1"
-py-buzz = "^4.0.0"
-pydantic = "^1.10.12"
 pyperclip = "^1.8.2"
 python-dotenv = "^1.0.0"
-python-jose = "^3.3.0"
 PyYAML = "6.*"
 rich = "^11.2.0"
 sentry-sdk = "^1.29.2"
@@ -40,6 +35,14 @@ typer = "^0.9.0"
 
 [tool.poetry.scripts]
 jobbergate = "jobbergate_cli.main:app"
+
+[tool.stickywheel]
+# This will resolve the relative path to the jobbergate-core package at build time
+# and pin its version based on the version in the jobbergate-cli pyproject.toml file.
+# Since it is at build time, there is no need to install the pluging on dev machines,
+# the deployment workflow will take care of it.
+# Reference: https://github.com/python-poetry/poetry/issues/6850#issuecomment-1445477319
+strategy = "exact"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.0"

--- a/jobbergate-cli/tests/subapps/conftest.py
+++ b/jobbergate-cli/tests/subapps/conftest.py
@@ -181,10 +181,6 @@ def dummy_job_submission_data(dummy_job_script_data):
             job_script_id=dummy_job_script_data[0]["id"],
             slurm_job_id=13,
             status="CREATED",
-            execution_parameters={
-                "name": "job-submission-name-1",
-                "comment": "I am a comment",
-            },
         ),
         dict(
             id=1,
@@ -196,10 +192,6 @@ def dummy_job_submission_data(dummy_job_script_data):
             job_script_id=88,
             slurm_job_id=8888,
             status="CREATED",
-            execution_parameters={
-                "name": "job-submission-name-2",
-                "comment": "I am a comment",
-            },
         ),
         dict(
             id=3,
@@ -211,10 +203,6 @@ def dummy_job_submission_data(dummy_job_script_data):
             job_script_id=99,
             slurm_job_id=9999,
             status="CREATED",
-            execution_parameters={
-                "name": "job-submission-name-3",
-                "comment": "I am a comment",
-            },
         ),
         dict(
             id=4,
@@ -227,10 +215,6 @@ def dummy_job_submission_data(dummy_job_script_data):
             slurm_job_id=9999,
             status="REJECTED",
             report_message="Failed to submit job to slurm",
-            execution_parameters={
-                "name": "job-submission-name-4",
-                "comment": "I am a comment",
-            },
         ),
     ]
 

--- a/jobbergate-cli/tests/subapps/job_scripts/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_app.py
@@ -248,10 +248,13 @@ def test_render__non_fast_mode_and_job_submission(
             content=dummy_module_source.encode(),
         ),
     )
-    mocked_create_job_submission = mocker.patch(
-        "jobbergate_cli.subapps.job_scripts.app.create_job_submission",
-        return_value=JobSubmissionResponse.parse_obj(job_submission_data),
+
+    submissions_handler = mock.MagicMock()
+    submissions_handler.run.return_value = JobSubmissionResponse.parse_obj(job_submission_data)
+    mocked_factory = mocker.patch(
+        "jobbergate_cli.subapps.job_scripts.app.job_submissions_factory", return_value=submissions_handler
     )
+
     mocker.patch.object(
         importlib.import_module("inquirer.prompt"),
         "ConsoleRender",
@@ -278,15 +281,7 @@ def test_render__non_fast_mode_and_job_submission(
         id=application_response.application_id,
         identifier=None,
     )
-    mocked_create_job_submission.assert_called_once_with(
-        jg_ctx=dummy_context,
-        job_script_id=job_script_data["id"],
-        name=job_script_data["name"],
-        description=job_script_data["description"],
-        cluster_name=None,
-        execution_directory=None,
-        sbatch_arguments=None,
-    )
+
     assert render_route.call_count == 1
     content = json.loads(render_route.calls.last.request.content)
     assert content == {
@@ -307,6 +302,16 @@ def test_render__non_fast_mode_and_job_submission(
             },
         },
     }
+
+    mocked_factory.assert_called_once_with(
+        jg_ctx=dummy_context,
+        job_script_id=job_script_data["id"],
+        name=job_script_data["name"],
+        description=job_script_data["description"],
+        cluster_name=None,
+        execution_directory=None,
+        sbatch_arguments=None,
+    )
 
     mocked_render.assert_has_calls(
         [

--- a/jobbergate-cli/tests/subapps/job_scripts/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_app.py
@@ -285,7 +285,7 @@ def test_render__non_fast_mode_and_job_submission(
         description=job_script_data["description"],
         cluster_name=None,
         execution_directory=None,
-        execution_parameters_file=None,
+        sbatch_arguments=None,
     )
     assert render_route.call_count == 1
     content = json.loads(render_route.calls.last.request.content)

--- a/jobbergate-cli/tests/subapps/job_submissions/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_app.py
@@ -1,4 +1,3 @@
-import json
 import shlex
 
 import httpx
@@ -32,9 +31,6 @@ def test_create(
     job_submission_description = job_submission_data.description
     job_script_id = job_submission_data.job_script_id
 
-    param_file_path = tmp_path / "param_file.json"
-    param_file_path.write_text(json.dumps(job_submission_data.execution_parameters))
-
     mocked_render = mocker.patch("jobbergate_cli.subapps.job_submissions.app.render_single_result")
     patched_create_job_submission = mocker.patch(
         "jobbergate_cli.subapps.job_submissions.app.create_job_submission",
@@ -50,7 +46,6 @@ def test_create(
                 create {flag_name}{separator}{job_submission_name}
                        --description='{job_submission_description}'
                        {flag_job_script_id}{separator}{job_script_id}
-                       --execution-parameters={param_file_path}
                        --download
                 """
             )

--- a/jobbergate-cli/tests/subapps/job_submissions/test_app.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_app.py
@@ -1,4 +1,5 @@
 import shlex
+from unittest import mock
 
 import httpx
 import pytest
@@ -21,7 +22,6 @@ def test_create(
     dummy_job_submission_data,
     cli_runner,
     mocker,
-    tmp_path,
     flag_name,
     flag_job_script_id,
     separator,
@@ -32,10 +32,12 @@ def test_create(
     job_script_id = job_submission_data.job_script_id
 
     mocked_render = mocker.patch("jobbergate_cli.subapps.job_submissions.app.render_single_result")
-    patched_create_job_submission = mocker.patch(
-        "jobbergate_cli.subapps.job_submissions.app.create_job_submission",
+
+    submissions_handler = mock.MagicMock()
+    submissions_handler.run.return_value = job_submission_data
+    mocked_factory = mocker.patch(
+        "jobbergate_cli.subapps.job_submissions.app.job_submissions_factory", return_value=submissions_handler
     )
-    patched_create_job_submission.return_value = job_submission_data
 
     test_app = make_test_app("create", create)
     result = cli_runner.invoke(
@@ -52,6 +54,17 @@ def test_create(
         ),
     )
     assert result.exit_code == 0, f"create failed: {result.stdout}"
+
+    mocked_factory.assert_called_once_with(
+        dummy_context,
+        job_script_id,
+        job_submission_name,
+        description=job_submission_description,
+        execution_directory=None,
+        cluster_name=None,
+        sbatch_arguments=[],
+        download=True,
+    )
 
     mocked_render.assert_called_once_with(
         dummy_context,

--- a/jobbergate-cli/tests/subapps/job_submissions/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_tools.py
@@ -1,322 +1,389 @@
-import json
 import pathlib
+from unittest import mock
 
 import httpx
 import pytest
 
 from jobbergate_cli.exceptions import Abort
-from jobbergate_cli.schemas import JobSubmissionResponse
-from jobbergate_cli.subapps.job_submissions.tools import create_job_submission, fetch_job_submission_data
+from jobbergate_cli.schemas import JobScriptResponse, JobSubmissionCreateRequestData, JobSubmissionResponse
+from jobbergate_cli.subapps.job_submissions.tools import (
+    OnsiteJobSubmission,
+    RemoteJobSubmission,
+    fetch_job_submission_data,
+    job_submissions_factory,
+)
 
 
-def test_create_job_submission__success(
-    respx_mock,
-    dummy_job_submission_data,
-    dummy_domain,
-    dummy_context,
-    attach_persona,
-    seed_clusters,
-):
-    job_submission_data = dummy_job_submission_data[0]
-    job_submission_name = job_submission_data["name"]
-    job_submission_description = job_submission_data["description"]
+@pytest.mark.parametrize("submission_cls", [OnsiteJobSubmission, RemoteJobSubmission])
+@pytest.mark.parametrize("organization_id", [None, "", "some-organization"])
+class TestJobSubmissionsClusterName:
+    def test_with_explicit_cluster_name(
+        self, dummy_context, attach_persona, submission_cls, organization_id, tweak_settings
+    ):
+        cluster_name = "test-cluster"
+        attach_persona("dummy@dummy.com", organization_id=organization_id)
+        with tweak_settings(DEFAULT_CLUSTER_NAME="default-cluster"):
+            submission_handler = submission_cls(
+                jg_ctx=dummy_context,
+                job_script_id=1,
+                name="test",
+                cluster_name=cluster_name,
+            )
+        expected_cluster_name = cluster_name
+        if organization_id:
+            expected_cluster_name += f"-{organization_id}"
+        assert submission_handler.cluster_name == expected_cluster_name
 
-    job_script_id = job_submission_data["job_script_id"]
+    def test_default_cluster_name(self, dummy_context, attach_persona, submission_cls, organization_id, tweak_settings):
+        cluster_name = "default-cluster"
+        attach_persona("dummy@dummy.com", organization_id=organization_id)
+        with tweak_settings(DEFAULT_CLUSTER_NAME=cluster_name):
+            submission_handler = submission_cls(
+                jg_ctx=dummy_context,
+                job_script_id=1,
+                name="test",
+            )
+        expected_cluster_name = cluster_name
+        if organization_id:
+            expected_cluster_name += f"-{organization_id}"
+        assert submission_handler.cluster_name == expected_cluster_name
 
-    create_job_submission_route = respx_mock.post(f"{dummy_domain}/jobbergate/job-submissions")
-    create_job_submission_route.mock(
-        return_value=httpx.Response(
-            httpx.codes.CREATED,
-            json=job_submission_data,
-        ),
-    )
+    def test_throws_exception_with_no_explicit_or_default_cluster_name(
+        self, dummy_context, attach_persona, submission_cls, organization_id, tweak_settings
+    ):
+        attach_persona("dummy@dummy.com", organization_id=organization_id)
+        with (
+            tweak_settings(DEFAULT_CLUSTER_NAME=None),
+            pytest.raises(ValueError, match="No cluster name supplied and no default exists"),
+        ):
+            submission_cls(
+                jg_ctx=dummy_context,
+                job_script_id=1,
+                name="test",
+            )
 
-    attach_persona("dummy@dummy.com")
-    seed_clusters("dummy-cluster")
-
-    new_job_submission = create_job_submission(
-        dummy_context,
-        job_script_id,
-        job_submission_name,
-        job_submission_description,
-        cluster_name="dummy-cluster",
-    )
-    assert new_job_submission == JobSubmissionResponse(**job_submission_data)
-
-
-def test_create_job_submission__with_explicit_cluster_name(
-    respx_mock,
-    dummy_job_submission_data,
-    dummy_domain,
-    dummy_context,
-    attach_persona,
-    seed_clusters,
-):
-    job_submission_data = dummy_job_submission_data[0]
-    job_submission_name = job_submission_data["name"]
-    job_submission_description = job_submission_data["description"]
-
-    job_script_id = job_submission_data["job_script_id"]
-
-    create_job_submission_route = respx_mock.post(f"{dummy_domain}/jobbergate/job-submissions")
-    create_job_submission_route.mock(
-        return_value=httpx.Response(
-            httpx.codes.CREATED,
-            json=job_submission_data,
-        ),
-    )
-
-    attach_persona("dummy@dummy.com")
-    seed_clusters("other-cluster")
-
-    new_job_submission = create_job_submission(
-        dummy_context,
-        job_script_id,
-        job_submission_name,
-        description=job_submission_description,
-        cluster_name="other-cluster",
-    )
-    assert new_job_submission == JobSubmissionResponse(**job_submission_data)
-
-    assert json.loads(create_job_submission_route.calls.last.request.content)["client_id"] == "other-cluster"
+    def test_with_organization_id_on_cluster_name(
+        self, dummy_context, attach_persona, submission_cls, organization_id, tweak_settings
+    ):
+        cluster_name = "test-cluster"
+        if organization_id:
+            cluster_name += f"-{organization_id}"
+        attach_persona("dummy@dummy.com", organization_id=organization_id)
+        with tweak_settings(DEFAULT_CLUSTER_NAME="default-cluster"):
+            submission_handler = submission_cls(
+                jg_ctx=dummy_context,
+                job_script_id=1,
+                name="test",
+                cluster_name=cluster_name,
+            )
+        assert submission_handler.cluster_name == cluster_name
 
 
-def test_create_job_submission__with_default_cluster_name(
-    respx_mock,
-    dummy_job_submission_data,
-    dummy_domain,
-    dummy_context,
-    attach_persona,
-    seed_clusters,
-    tweak_settings,
-):
-    job_submission_data = dummy_job_submission_data[0]
-    job_submission_name = job_submission_data["name"]
-    job_submission_description = job_submission_data["description"]
+@pytest.mark.parametrize("submission_cls", [OnsiteJobSubmission, RemoteJobSubmission])
+@pytest.mark.parametrize(
+    "execution_directory", [pathlib.Path("./some/relative/path"), pathlib.Path("/some/absolute/path"), None]
+)
+class TestJobSubmissionsExecutionDirectory:
+    def test_execution_directory_is_absolute(self, dummy_context, attach_persona, submission_cls, execution_directory):
+        attach_persona("dummy@dummy.com")
 
-    job_script_id = job_submission_data["job_script_id"]
-
-    create_job_submission_route = respx_mock.post(f"{dummy_domain}/jobbergate/job-submissions")
-    create_job_submission_route.mock(
-        return_value=httpx.Response(
-            httpx.codes.CREATED,
-            json=job_submission_data,
-        ),
-    )
-
-    attach_persona("dummy@dummy.com")
-    seed_clusters("other-cluster")
-
-    with tweak_settings(DEFAULT_CLUSTER_NAME="default-cluster"):
-        new_job_submission = create_job_submission(
-            dummy_context,
-            job_script_id,
-            job_submission_name,
-            description=job_submission_description,
-        )
-        assert new_job_submission == JobSubmissionResponse(**job_submission_data)
-
-    assert json.loads(create_job_submission_route.calls.last.request.content)["client_id"] == "default-cluster"
-
-
-def test_create_job_submission__throws_exception_with_no_explicit_or_default_cluster_name(
-    respx_mock,
-    dummy_job_submission_data,
-    dummy_domain,
-    dummy_context,
-    attach_persona,
-):
-    job_submission_data = dummy_job_submission_data[0]
-    job_submission_name = job_submission_data["name"]
-    job_submission_description = job_submission_data["description"]
-
-    job_script_id = job_submission_data["job_script_id"]
-
-    create_job_submission_route = respx_mock.post(f"{dummy_domain}/jobbergate/job-submissions")
-    create_job_submission_route.mock(
-        return_value=httpx.Response(
-            httpx.codes.CREATED,
-            json=job_submission_data,
-        ),
-    )
-
-    attach_persona("dummy@dummy.com")
-
-    with pytest.raises(Abort, match="unknown cluster"):
-        create_job_submission(
-            dummy_context,
-            job_script_id,
-            job_submission_name,
-            description=job_submission_description,
+        submission_handler = submission_cls(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            execution_directory=execution_directory,
+            cluster_name="test-cluster",
         )
 
+        assert submission_handler.execution_directory.is_absolute()
 
-def test_create_job_submission__with_explicit_execution_dir(
-    respx_mock,
-    dummy_job_submission_data,
-    dummy_domain,
-    dummy_context,
-    attach_persona,
-    seed_clusters,
-):
-    job_submission_data = dummy_job_submission_data[0]
-    job_submission_name = job_submission_data["name"]
-    job_submission_description = job_submission_data["description"]
+        if execution_directory is None:
+            # Default value
+            execution_directory = pathlib.Path.cwd()
 
-    job_script_id = job_submission_data["job_script_id"]
+        expected_execution_directory = execution_directory.resolve()
+        assert submission_handler.execution_directory == expected_execution_directory
 
-    create_job_submission_route = respx_mock.post(f"{dummy_domain}/jobbergate/job-submissions")
-    create_job_submission_route.mock(
-        return_value=httpx.Response(
-            httpx.codes.CREATED,
-            json=job_submission_data,
-        ),
-    )
 
+class TestJobSubmissionsGetRequestData:
+    def test_handle_request_data__on_site(self, dummy_context, attach_persona):
+        attach_persona("dummy@dummy.com")
+
+        dummy_data = dict(
+            job_script_id=1,
+            name="test",
+            execution_directory=pathlib.Path("/some/fake/path"),
+            sbatch_arguments=["--partition=debug", "--time=1:00:00"],
+            description="test description",
+            cluster_name="test-cluster",
+        )
+
+        submission_handler = OnsiteJobSubmission(jg_ctx=dummy_context, download=True, **dummy_data)
+
+        # simulate process_submission by setting slurm_job_id
+        dummy_data["slurm_job_id"] = 1234
+        submission_handler.slurm_job_id = dummy_data["slurm_job_id"]
+
+        actual_request_data = submission_handler.get_request_data()
+        expected_request_data = JobSubmissionCreateRequestData.parse_obj(dummy_data)
+
+        assert actual_request_data == expected_request_data
+
+    def test_handle_request_data__remote(self, dummy_context, attach_persona, dummy_domain, respx_mock):
+        attach_persona("dummy@dummy.com")
+
+        dummy_data = dict(
+            job_script_id=1,
+            name="test",
+            execution_directory=pathlib.Path("/some/fake/path"),
+            sbatch_arguments=["--partition=debug", "--time=1:00:00"],
+            description="test description",
+            cluster_name="test-cluster",
+        )
+
+        submission_handler = RemoteJobSubmission(jg_ctx=dummy_context, download=True, **dummy_data)
+
+        actual_request_data = submission_handler.get_request_data()
+        expected_request_data = JobSubmissionCreateRequestData.parse_obj(dummy_data)
+
+        assert actual_request_data == expected_request_data
+
+
+@pytest.mark.parametrize("submission_cls", [OnsiteJobSubmission, RemoteJobSubmission])
+class TestJobSubmissionsMakePostRequest:
+    def test_post_request__success(
+        self, dummy_context, attach_persona, submission_cls, dummy_job_submission_data, respx_mock, dummy_domain
+    ):
+        attach_persona("dummy@dummy.com")
+        job_submission_data = dummy_job_submission_data[0]
+
+        submission_handler = submission_cls(
+            jg_ctx=dummy_context,
+            job_script_id=job_submission_data["job_script_id"],
+            name=job_submission_data["name"],
+            cluster_name="test-cluster",
+        )
+
+        create_job_submission_data = JobSubmissionCreateRequestData.parse_obj(job_submission_data)
+        create_job_submission_route = respx_mock.post(f"{dummy_domain}/jobbergate/job-submissions")
+        create_job_submission_route.mock(
+            return_value=httpx.Response(
+                httpx.codes.CREATED,
+                json=job_submission_data,
+            ),
+        )
+
+        actual_response = submission_handler.make_post_request(create_job_submission_data)
+        expected_response = JobSubmissionResponse.parse_obj(job_submission_data)
+
+        assert actual_response == expected_response
+
+
+class TestJobSubmissionsProcessSubmissions:
+    def test_process_submission__remote_download(self, dummy_context, mocker, attach_persona):
+        attach_persona("dummy@dummy.com")
+        submission_handler = RemoteJobSubmission(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            cluster_name="test-cluster",
+            download=True,
+        )
+        mocked_download_job_script_files = mocker.patch(
+            "jobbergate_cli.subapps.job_submissions.tools.download_job_script_files"
+        )
+        submission_handler.process_submission()
+        mocked_download_job_script_files.assert_called_once_with(
+            submission_handler.job_script_id, submission_handler.jg_ctx, submission_handler.execution_directory
+        )
+
+    def test_process_submission__no_remote_download(self, dummy_context, mocker, attach_persona):
+        attach_persona("dummy@dummy.com")
+        submission_handler = RemoteJobSubmission(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            cluster_name="test-cluster",
+            download=False,
+        )
+        mocked_download_job_script_files = mocker.patch(
+            "jobbergate_cli.subapps.job_submissions.tools.download_job_script_files"
+        )
+        submission_handler.process_submission()
+        mocked_download_job_script_files.assert_not_called()
+
+    def test_process_submission__on_site_abort_if_sbatch_path_is_unset(
+        self, dummy_context, attach_persona, tweak_settings
+    ):
+        attach_persona("dummy@dummy.com")
+        submission_handler = OnsiteJobSubmission(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            cluster_name="test-cluster",
+        )
+
+        with (
+            tweak_settings(SBATCH_PATH=None),
+            pytest.raises(Abort, match="SBATCH_PATH most be set for onsite submissions"),
+        ):
+            submission_handler.process_submission()
+
+    class DummyFile:
+        @property
+        def file_type(self):
+            return "NOT-ENTRYPOINT"
+
+    @pytest.mark.parametrize("job_script_files", [[], [DummyFile(), DummyFile()]])
+    def test_process_submission__on_site_abort_if_not_exact_one_entrypoint_file_is_found(
+        self, job_script_files, dummy_context, attach_persona, tweak_settings, mocker, tmp_path
+    ):
+        attach_persona("dummy@dummy.com")
+        submission_handler = OnsiteJobSubmission(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            cluster_name="test-cluster",
+        )
+
+        mocker.patch(
+            "jobbergate_cli.subapps.job_submissions.tools.download_job_script_files", return_value=job_script_files
+        )
+
+        with (
+            tweak_settings(SBATCH_PATH=tmp_path),
+            pytest.raises(Abort, match="There should be exactly one entrypoint file in the parent job script"),
+        ):
+            submission_handler.process_submission()
+
+    @pytest.mark.parametrize("download", [True, False])
+    def test_process_submission__on_site_success(
+        self, download, dummy_context, attach_persona, tweak_settings, mocker, tmp_path, dummy_job_script_data
+    ):
+        attach_persona("dummy@dummy.com")
+
+        job_script_data = JobScriptResponse.parse_obj(dummy_job_script_data[0])
+
+        submission_handler = OnsiteJobSubmission(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            cluster_name="test-cluster",
+            download=download,
+            execution_directory=tmp_path,
+        )
+
+        mocked_download_job_script_files = mocker.patch(
+            "jobbergate_cli.subapps.job_submissions.tools.download_job_script_files", return_value=job_script_data.files
+        )
+        mocked_inject_sbatch_params = mocker.patch.object(submission_handler, "inject_sbatch_params")
+
+        mocked_sbatch = mock.MagicMock()
+        mocked_sbatch.submit_job = lambda *args, **kwargs: 13
+        mocker.patch("jobbergate_cli.subapps.job_submissions.tools.SubmissionHandler", return_value=mocked_sbatch)
+
+        with tweak_settings(SBATCH_PATH=tmp_path):
+            submission_handler.process_submission()
+
+        assert submission_handler.slurm_job_id == 13
+
+        # files are downloaded anyway for on-site submissions
+        mocked_download_job_script_files.assert_called_once_with(1, dummy_context, tmp_path)
+        assert mocked_inject_sbatch_params.call_count == 1
+
+    def test_inject_sbatch_params__on_site(self, mocker, attach_persona, dummy_context, tmp_path):
+        attach_persona("dummy@dummy.com")
+        submission_handler = OnsiteJobSubmission(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            cluster_name="test-cluster",
+            execution_directory=tmp_path,
+            sbatch_arguments=["--partition=debug", "--time=1:00:00"],
+        )
+
+        job_script_path = tmp_path / "entrypoint.sh"
+
+        job_script_path.write_text("original content")
+
+        mocked_inject_sbatch_params = mocker.patch(
+            "jobbergate_cli.subapps.job_submissions.tools.inject_sbatch_params", return_value="inject_sbatch_params"
+        )
+
+        submission_handler.inject_sbatch_params(job_script_path)
+
+        mocked_inject_sbatch_params.assert_called_once_with(
+            "original content", ["--partition=debug", "--time=1:00:00"], "Injected at submission time by Jobbergate CLI"
+        )
+        assert job_script_path.read_text() == "inject_sbatch_params"
+
+    def test_skip_inject_sbatch_params__on_site(self, mocker, attach_persona, dummy_context, tmp_path):
+        attach_persona("dummy@dummy.com")
+        submission_handler = OnsiteJobSubmission(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            cluster_name="test-cluster",
+            execution_directory=tmp_path,
+            sbatch_arguments=[],
+        )
+
+        job_script_path = tmp_path / "entrypoint.sh"
+
+        job_script_path.write_text("original content")
+
+        mocked_inject_sbatch_params = mocker.patch("jobbergate_cli.subapps.job_submissions.tools.inject_sbatch_params")
+
+        submission_handler.inject_sbatch_params(job_script_path)
+
+        assert mocked_inject_sbatch_params.call_count == 0
+        assert job_script_path.read_text() == "original content"
+
+
+@pytest.mark.parametrize("submission_cls", [OnsiteJobSubmission, RemoteJobSubmission])
+class TestJobSubmissionsRun:
+    def test_run__success(self, dummy_context, attach_persona, submission_cls, mocker):
+        attach_persona("dummy@dummy.com")
+        submission_handler = submission_cls(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            cluster_name="test-cluster",
+        )
+
+        mocked_process_submission = mocker.patch.object(submission_handler, "process_submission")
+        mocked_get_request_data = mocker.patch.object(
+            submission_handler, "get_request_data", return_value="request_data"
+        )
+        mocked_make_post_request = mocker.patch.object(submission_handler, "make_post_request", return_value="response")
+
+        actual_response = submission_handler.run()
+
+        assert actual_response == "response"
+        mocked_process_submission.assert_called_once()
+        mocked_get_request_data.assert_called_once()
+        mocked_make_post_request.assert_called_once_with("request_data")
+
+
+@pytest.mark.parametrize(
+    "submission_cls,sbatch_path", [[OnsiteJobSubmission, "/usr/bin/sbatch"], [RemoteJobSubmission, None]]
+)
+def test_job_submissions_factory(submission_cls, sbatch_path, attach_persona, dummy_context, tweak_settings):
     attach_persona("dummy@dummy.com")
-    seed_clusters("dummy-cluster")
-
-    create_job_submission(
-        dummy_context,
-        job_script_id,
-        job_submission_name,
-        job_submission_description,
-        cluster_name="dummy-cluster",
-        execution_directory=pathlib.Path("/some/fake/path"),
-    )
-    payload = json.loads(create_job_submission_route.calls.last.request.content)
-    assert payload["execution_directory"] == "/some/fake/path"
-
-    create_job_submission(
-        dummy_context,
-        job_script_id,
-        job_submission_name,
-        job_submission_description,
-        cluster_name="dummy-cluster",
-        execution_directory=pathlib.Path("./some/relative/path"),
-    )
-    payload = json.loads(create_job_submission_route.calls.last.request.content)
-    assert payload["execution_directory"] == str(pathlib.Path.cwd() / "./some/relative/path")
-
-
-def test_create_job_submission__with_default_execution_dir(
-    mocker,
-    respx_mock,
-    dummy_job_submission_data,
-    dummy_domain,
-    dummy_context,
-    attach_persona,
-    seed_clusters,
-):
-    job_submission_data = dummy_job_submission_data[0]
-    job_submission_name = job_submission_data["name"]
-    job_submission_description = job_submission_data["description"]
-
-    job_script_id = job_submission_data["job_script_id"]
-
-    create_job_submission_route = respx_mock.post(f"{dummy_domain}/jobbergate/job-submissions")
-    create_job_submission_route.mock(
-        return_value=httpx.Response(
-            httpx.codes.CREATED,
-            json=job_submission_data,
-        ),
-    )
-
-    attach_persona("dummy@dummy.com")
-    seed_clusters("dummy-cluster")
-
-    mocker.patch("jobbergate_cli.subapps.job_submissions.tools.Path.cwd", return_value=pathlib.Path("/some/fake/path"))
-
-    create_job_submission(
-        dummy_context,
-        job_script_id,
-        job_submission_name,
-        job_submission_description,
-        cluster_name="dummy-cluster",
-        execution_directory=None,
-    )
-    payload = json.loads(create_job_submission_route.calls.last.request.content)
-    assert payload["execution_directory"] == "/some/fake/path"
-
-
-def test_create_job_submission__in_multitenancy_mode_with_org_id(
-    respx_mock,
-    dummy_job_submission_data,
-    dummy_domain,
-    dummy_context,
-    attach_persona,
-    seed_clusters,
-):
-    job_submission_data = dummy_job_submission_data[0]
-    job_submission_name = job_submission_data["name"]
-    job_submission_description = job_submission_data["description"]
-
-    job_script_id = job_submission_data["job_script_id"]
-
-    create_job_submission_route = respx_mock.post(f"{dummy_domain}/jobbergate/job-submissions")
-    create_job_submission_route.mock(
-        return_value=httpx.Response(
-            httpx.codes.CREATED,
-            json=job_submission_data,
-        ),
-    )
-
-    attach_persona("dummy@dummy.com", organization_id="some-organization")
-    seed_clusters("other-cluster-some-organization")
-
-    new_job_submission = create_job_submission(
-        dummy_context,
-        job_script_id,
-        job_submission_name,
-        description=job_submission_description,
-        cluster_name="other-cluster",
-    )
-    assert new_job_submission == JobSubmissionResponse(**job_submission_data)
-
-    assert (
-        json.loads(create_job_submission_route.calls.last.request.content)["client_id"]
-        == "other-cluster-some-organization"
-    )
-
-
-def test_create_job_submission__in_multitenancy_mode_with_org_id_and_cluster_name_already_has_org_id(
-    respx_mock,
-    dummy_job_submission_data,
-    dummy_domain,
-    dummy_context,
-    attach_persona,
-    seed_clusters,
-):
-    job_submission_data = dummy_job_submission_data[0]
-    job_submission_name = job_submission_data["name"]
-    job_submission_description = job_submission_data["description"]
-
-    job_script_id = job_submission_data["job_script_id"]
-
-    create_job_submission_route = respx_mock.post(f"{dummy_domain}/jobbergate/job-submissions")
-    create_job_submission_route.mock(
-        return_value=httpx.Response(
-            httpx.codes.CREATED,
-            json=job_submission_data,
-        ),
-    )
-
-    attach_persona("dummy@dummy.com", organization_id="some-organization")
-    seed_clusters("other-cluster-some-organization")
-
-    new_job_submission = create_job_submission(
-        dummy_context,
-        job_script_id,
-        job_submission_name,
-        description=job_submission_description,
-        cluster_name="other-cluster-some-organization",
-    )
-    assert new_job_submission == JobSubmissionResponse(**job_submission_data)
-
-    assert (
-        json.loads(create_job_submission_route.calls.last.request.content)["client_id"]
-        == "other-cluster-some-organization"
-    )
+    with tweak_settings(SBATCH_PATH=sbatch_path):
+        submission_handler = job_submissions_factory(
+            jg_ctx=dummy_context,
+            job_script_id=1,
+            name="test",
+            cluster_name="test-cluster",
+            download=True,
+        )
+    assert isinstance(submission_handler, submission_cls)
+    assert submission_handler.jg_ctx == dummy_context
+    assert submission_handler.job_script_id == 1
+    assert submission_handler.name == "test"
+    assert submission_handler.cluster_name == "test-cluster"
+    assert submission_handler.download is True
 
 
 def test_fetch_job_submission_data__success__using_id(

--- a/jobbergate-cli/tests/subapps/job_submissions/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_submissions/test_tools.py
@@ -6,7 +6,7 @@ import pytest
 
 from jobbergate_cli.exceptions import Abort
 from jobbergate_cli.schemas import JobSubmissionResponse
-from jobbergate_cli.subapps.job_submissions.tools import create_job_submission, fetch_job_submission_data, sbatch_run
+from jobbergate_cli.subapps.job_submissions.tools import create_job_submission, fetch_job_submission_data
 
 
 def test_create_job_submission__success(
@@ -339,60 +339,3 @@ def test_fetch_job_submission_data__success__using_id(
     assert fetch_route.called
     assert result == JobSubmissionResponse(**job_submission_data)
     assert result.report_message == job_submission_data.get("report_message")
-
-
-class TestSbatchRun:
-    def test_valid_arguments_returns_slurm_id(self, mocker, tweak_settings, tmp_path):
-        mocked_popen = mocker.MagicMock()
-        mocker.patch("jobbergate_cli.subapps.job_submissions.tools.Popen", return_value=mocked_popen)
-        mocked_popen.communicate.return_value = (b"Submitted batch job 123", b"")
-        mocked_popen.returncode = 0
-
-        with tweak_settings(SBATCH_PATH=tmp_path):
-            slurm_id = sbatch_run("filename.sh")
-
-        assert slurm_id == 123
-
-    def test_raises_abort_if_sbatch_command_returns_non_zero_exit_code(
-        self,
-        mocker,
-        tweak_settings,
-        tmp_path,
-    ):
-        mocked_popen = mocker.MagicMock()
-        mocker.patch("jobbergate_cli.subapps.job_submissions.tools.Popen", return_value=mocked_popen)
-        mocked_popen.communicate.return_value = (b"", b"Error: Invalid argument")
-        mocked_popen.returncode = 1
-
-        with tweak_settings(SBATCH_PATH=tmp_path):
-            with pytest.raises(
-                Abort,
-                match="^Failed to execute submission with error",
-            ):
-                sbatch_run("filename.sh")
-
-    def test_raises_abort_if_slurm_job_id_cannot_be_parsed_from_output(
-        self,
-        mocker,
-        tweak_settings,
-        tmp_path,
-    ):
-        mocked_popen = mocker.MagicMock()
-        mocker.patch("jobbergate_cli.subapps.job_submissions.tools.Popen", return_value=mocked_popen)
-        mocked_popen.communicate.return_value = (b"Invalid output", b"")
-        mocked_popen.returncode = 0
-
-        with tweak_settings(SBATCH_PATH=tmp_path):
-            with pytest.raises(
-                Abort,
-                match="^Failed to parse slurm job id from output=",
-            ):
-                sbatch_run("filename.sh")
-
-    def test_raises_abort_if_sbatch_path_not_set_or_does_not_exist(self, tweak_settings, tmp_path):
-        with tweak_settings(SBATCH_PATH=tmp_path / "nonexistent"):
-            with pytest.raises(
-                Abort,
-                match="^The path to the sbatch executable is not set or does not exist",
-            ):
-                sbatch_run("filename.sh")

--- a/jobbergate-cli/tests/test_config.py
+++ b/jobbergate-cli/tests/test_config.py
@@ -36,3 +36,9 @@ def test_cache_dir__expands_user_and_resolves():
     settings = Settings(JOBBERGATE_CACHE_DIR="~/.jobbergate-cli-prod")
     assert settings.JOBBERGATE_CACHE_DIR == Path.home() / ".jobbergate-cli-prod"
     assert settings.JOBBERGATE_CACHE_DIR.is_absolute()
+
+
+@pytest.mark.parametrize("sbatch_path, is_onsite_mode", [[None, False], ["/usr/bin/sbatch", True]])
+def test_is_onsite_mode__is_true_when_sbatch_path_is_set(sbatch_path, is_onsite_mode):
+    settings = Settings(SBATCH_PATH=sbatch_path)
+    assert settings.is_onsite_mode == is_onsite_mode

--- a/jobbergate-composed/docker-compose.yml
+++ b/jobbergate-composed/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       - jobbergate-net
     volumes:
       - ../jobbergate-cli/jobbergate_cli/:/app/jobbergate_cli/
+      - ../jobbergate-core/:/jobbergate-core
       - ../examples/simple-application/:/simple-example/
       - ../examples/motorbike-application/:/motorbike-example/
       - ./etc/run-motorbike.py:/app/run-motorbike

--- a/jobbergate-core/poetry.lock
+++ b/jobbergate-core/poetry.lock
@@ -1145,4 +1145,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4c3443de8c7e7b460c5a4c84dd1f77900b119bcd74da3361e1495a7958db7ac9"
+content-hash = "65b459976ce45dd8d87cb773c8fb991065ddd77f3ea70d41aa9d4e9bec49144f"

--- a/jobbergate-core/pyproject.toml
+++ b/jobbergate-core/pyproject.toml
@@ -24,7 +24,7 @@ httpx = "^0.24.1"
 loguru = "^0.6.0"
 pendulum = "3.0.0b1"
 py-buzz = "^4.0.0"
-pydantic = "^1.8.2"
+pydantic = "^1.10.12"
 python-jose = "^3.3.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
#### What
- Dropped support for Python 3.8 and 3.9
- Added Jobbergate-core as a project dependency to reuse key components
- Refactored on-site submission to use the new `jobbergate-core` components
- Replaced `execution_parameters` by `sbatch_arguments` on job submission
- Refactored `jobbergate_cli.subapps.job_submissions.tools.create_submission` into two classes in the same module to reduce complexity in the codebase

#### Why
This is the work on the CLI side to replace slurmrestd by sbatch. Additional changes were made to reduce complexity and duplication on the codebase, besides to increase test coverage.

`Task`: https://jira.scania.com/browse/ASP-4586

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
