### PR TITLE
PENG-2152 Coerced empty identifiers to None values

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
 
+- Added logic to coerce empty `identifier` on job script templates to a `None` value [PENG-2152]
+- Added logic disallow empty `name` on job script templates [PENG-2152]
 
 ## 5.0.0a1 -- 2024-04-04
 ## 5.0.0a0 -- 2024-03-26

--- a/jobbergate-api/jobbergate_api/apps/job_script_templates/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_script_templates/schemas.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 import pydantic
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from jobbergate_api.apps.constants import FileType
 from jobbergate_api.apps.schemas import LengthLimitedStr, TableResource
@@ -116,6 +116,24 @@ class JobTemplateCreateRequest(BaseModel):
     description: LengthLimitedStr | None
     template_vars: dict[LengthLimitedStr, Any] | None
 
+    @validator("name")
+    def not_empty_str(cls, value):
+        """
+        Do not allow a string value to be empty.
+        """
+        if value == "":
+            raise ValueError("Cannot be an empty string")
+        return value
+
+    @validator("identifier")
+    def empty_str_to_none(cls, value):
+        """
+        Coerce an empty string value to None.
+        """
+        if value == "":
+            return None
+        return value
+
     class Config:
         schema_extra = job_template_meta_mapper
 
@@ -127,6 +145,24 @@ class JobTemplateCloneRequest(BaseModel):
     identifier: LengthLimitedStr | None
     description: LengthLimitedStr | None
     template_vars: dict[LengthLimitedStr, Any] | None
+
+    @validator("name")
+    def not_empty_str(cls, value):
+        """
+        Do not allow a string value to be empty.
+        """
+        if value == "":
+            raise ValueError("Cannot be an empty string")
+        return value
+
+    @validator("identifier")
+    def empty_str_to_none(cls, value):
+        """
+        Coerce an empty string value to None.
+        """
+        if value == "":
+            return None
+        return value
 
     class Config:
         schema_extra = job_template_meta_mapper
@@ -140,6 +176,24 @@ class JobTemplateUpdateRequest(BaseModel):
     description: LengthLimitedStr | None
     template_vars: dict[LengthLimitedStr, Any] | None
     is_archived: bool | None
+
+    @validator("name")
+    def not_empty_str(cls, value):
+        """
+        Do not allow a string value to be empty.
+        """
+        if value == "":
+            raise ValueError("Cannot be an empty string")
+        return value
+
+    @validator("identifier")
+    def empty_str_to_none(cls, value):
+        """
+        Coerce an empty string value to None.
+        """
+        if value == "":
+            return None
+        return value
 
     class Config:
         schema_extra = job_template_meta_mapper

--- a/jobbergate-api/tests/apps/job_submissions/test_schemas.py
+++ b/jobbergate-api/tests/apps/job_submissions/test_schemas.py
@@ -1,4 +1,5 @@
 import pytest
+
 from jobbergate_api.apps.job_submissions.schemas import JobSubmissionCreateRequest, JobSubmissionUpdateRequest
 
 


### PR DESCRIPTION
Added validators to make sure that the value for `identifier` is coerced to `None` if the string is empty.

Also added a validator to make sure that the `name` field cannot be empty.

Added unit tests for the added logic.
---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
