### PR TITLE
[PENG-2070] Allow files to be renamed in upsert routes  in Jobbergate API

### DIFF
--- a/jobbergate-agent/pyproject.toml
+++ b/jobbergate-agent/pyproject.toml
@@ -77,6 +77,7 @@ asyncio_mode = "auto"
 addopts = [
     "--random-order",
     "--cov=jobbergate_agent",
+    "--cov-report=term",
     "--cov-report=xml:tests/coverage.xml",
 ]
 env = [

--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -5,6 +5,7 @@ This file keeps track of all notable changes to jobbergate-api
 ## Unreleased
 
 - Enabled template and job-script files to be renamed on upsert routes [PENG-2070]
+- Added a response model for PUT on `/job-scripts/{id}/upload/{file_type}`
 
 ## 5.2.0a0 -- 2024-04-29
 

--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -4,8 +4,10 @@ This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
 
+- Enabled template and job-script files to be renamed on upsert routes [PENG-2070]
 
 ## 5.2.0a0 -- 2024-04-29
+
 - Expanded permission sets from view/edit to create/read/update/delete
 - Added admin role to allow key users to update/delete entities owned by others [ASP-4989]
 

--- a/jobbergate-api/jobbergate_api/apps/job_script_templates/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_script_templates/routers.py
@@ -214,25 +214,38 @@ async def job_script_template_get_file(
 @router.put(
     "/{id_or_identifier}/upload/template/{file_type}",
     status_code=status.HTTP_200_OK,
-    description="Endpoint to upload a file to a job script template by id or identifier",
+    description=(
+        "Endpoint to upload a file to a job script template by id or identifier. "
+        "If a previous filename is provided, the file will be renamed from that. "
+        "Upload file is optional in this scenario since the file content can be copied from previous file."
+    ),
     response_model=TemplateFileDetailedView,
 )
 async def job_script_template_upload_file(
     id_or_identifier: int | str = Path(),
     file_type: FileType = Path(),
-    upload_file: UploadFile = File(..., description="File to upload"),
+    filename: str | None = Query(None, max_length=255),
+    upload_file: UploadFile | None = File(None, description="File to upload"),
+    previous_filename: str | None = Query(
+        None, description="Previous name of the file in case a rename is needed", max_length=255
+    ),
     secure_services: SecureService = Depends(
         secure_services(Permissions.JOB_TEMPLATES_CREATE, ensure_email=True)
     ),
 ):
     """Upload a file to a job script template by id or identifier."""
-    if upload_file.filename is None:
+    # This is included for backwards compatibility with the previous implementation
+    # where filename was recovered from the upload_file object
+    filename = filename or getattr(upload_file, "filename")
+    if not filename:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="The upload file has no filename",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Filename must be provided either as a query parameter or as part of the file upload",
         )
 
-    logger.debug(f"Uploading file {upload_file.filename} to job script template {id_or_identifier=}")
+    logger.debug(
+        f"Uploading {filename=} to job template {id_or_identifier=}; {file_type=}; {previous_filename=}"
+    )
     job_script_template = await secure_services.crud.template.get(id_or_identifier)
     if Permissions.ADMIN not in secure_services.identity_payload.permissions:
         secure_services.crud.template.ensure_attribute(
@@ -241,8 +254,9 @@ async def job_script_template_upload_file(
 
     return await secure_services.file.template.upsert(
         parent_id=job_script_template.id,
-        filename=upload_file.filename,
+        filename=filename,
         upload_content=upload_file,
+        previous_filename=previous_filename,
         file_type=file_type,
     )
 

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/routers.py
@@ -19,6 +19,7 @@ from jobbergate_api.apps.job_scripts.schemas import (
     JobScriptCloneRequest,
     JobScriptCreateRequest,
     JobScriptDetailedView,
+    JobScriptFileDetailedView,
     JobScriptListView,
     JobScriptUpdateRequest,
     RenderFromTemplateRequest,
@@ -298,6 +299,7 @@ async def job_script_get_file(
         "If a previous filename is provided, the file will be renamed from that. "
         "Upload file is optional in this scenario since the file content can be copied from previous file."
     ),
+    response_model=JobScriptFileDetailedView,
 )
 async def job_script_upload_file(
     id: int = Path(...),
@@ -329,7 +331,7 @@ async def job_script_upload_file(
             job_script, owner_email=secure_services.identity_payload.email
         )
 
-    await secure_services.file.job_script.upsert(
+    return await secure_services.file.job_script.upsert(
         parent_id=job_script.id,
         filename=filename,
         upload_content=upload_file,

--- a/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
+++ b/jobbergate-api/jobbergate_api/apps/job_scripts/services.py
@@ -123,7 +123,8 @@ class JobScriptFileService(FileService):
         self,
         parent_id: int,
         filename: str,
-        upload_content: str | bytes | UploadFile,
+        upload_content: str | bytes | UploadFile | None,
+        previous_filename: str | None = None,
         **upsert_kwargs,
     ) -> FileModel:
         """
@@ -136,8 +137,8 @@ class JobScriptFileService(FileService):
             raise_kwargs=dict(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY),
         )
         if file_type == FileType.ENTRYPOINT:
-            await self.validate_entrypoint_file(parent_id, filename)
-        return await super().upsert(parent_id, filename, upload_content, **upsert_kwargs)
+            await self.validate_entrypoint_file(parent_id, previous_filename or filename)
+        return await super().upsert(parent_id, filename, upload_content, previous_filename, **upsert_kwargs)
 
     async def validate_entrypoint_file(self, parent_id: int, filename: str):
         """

--- a/jobbergate-api/pyproject.toml
+++ b/jobbergate-api/pyproject.toml
@@ -98,6 +98,7 @@ minversion = "7.0"
 addopts = [
     "--random-order",
     "--cov=jobbergate_api",
+    "--cov-report=term",
     "--cov-report=xml:tests/coverage.xml",
     "--no-flaky-report",
 ]

--- a/jobbergate-api/tests/apps/job_scripts/test_routers.py
+++ b/jobbergate-api/tests/apps/job_scripts/test_routers.py
@@ -861,14 +861,22 @@ class TestJobScriptFiles:
 
         assert response.status_code == status.HTTP_200_OK, f"Upsert failed: {response.text}"
 
-        job_script_file = await synth_services.file.job_script.get(id, "test_template.sh")
+        # Check the response from the upload endpoint
+        response_data = response.json()
+        assert response_data is not None
+        assert response_data["parent_id"] == id
+        assert response_data["filename"] == dummy_file_path.name
+        assert response_data["file_type"] == file_type
 
+        # Check the database
+        job_script_file = await synth_services.file.job_script.get(id, "test_template.sh")
         assert job_script_file is not None
         assert job_script_file.parent_id == id
         assert job_script_file.filename == dummy_file_path.name
         assert job_script_file.file_type == file_type
         assert job_script_file.file_key == f"job_script_files/{id}/{dummy_file_path.name}"
 
+        # Check the file content on s3
         file_content = await synth_services.file.job_script.get_file_content(job_script_file)
         assert file_content.decode() == job_script_data_as_string
 

--- a/jobbergate-cli/pyproject.toml
+++ b/jobbergate-cli/pyproject.toml
@@ -64,6 +64,7 @@ minversion = "7.0"
 addopts = [
     "--random-order",
     "--cov=jobbergate_cli",
+    "--cov-report=term",
     "--cov-report=xml:tests/coverage.xml",
 ]
 env = [

--- a/jobbergate-core/pyproject.toml
+++ b/jobbergate-core/pyproject.toml
@@ -47,6 +47,7 @@ minversion = "6.0"
 addopts = [
     "--random-order",
     "--cov=jobbergate_core",
+    "--cov-report=term",
     "--cov-report=xml:tests/coverage.xml",
 ]
 


### PR DESCRIPTION
#### What
- A new field was added to the upsert routes for the previous file name
- When the previous name doesn't match the new name, the file is renamed in the storage
- Fixed upsert on job-script files returning no data
- Unit tests were updated

#### Why
We need the users to be able to rename their files when they are being upserted.

`Task`: https://app.clickup.com/t/18022949/PENG-2070

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
