### PR TITLE
PENG-2248 Replaced deprecated pkg_resources dependency

### DIFF
--- a/jobbergate-agent/jobbergate_agent/internals/update.py
+++ b/jobbergate-agent/jobbergate_agent/internals/update.py
@@ -1,11 +1,11 @@
 import re
 import subprocess
 import sys
+from importlib.metadata import version
 
 from apscheduler.job import Job
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from loguru import logger
-from pkg_resources import get_distribution
 
 from jobbergate_agent.clients.cluster_api import backend_client as jobbergate_api_client
 
@@ -78,7 +78,7 @@ async def self_update_agent():
     """
     global scheduler
 
-    current_version = get_distribution(package_name).version
+    current_version = version(package_name)
     upstream_version = await _fetch_upstream_version_info()
     logger.debug(
         f"Jobbergate Agent version info: current_version={current_version}, upstream_version={upstream_version}"

--- a/jobbergate-agent/tests/internals/test_update.py
+++ b/jobbergate-agent/tests/internals/test_update.py
@@ -117,7 +117,7 @@ def test_update_package(mocked_sys: mock.MagicMock, mocked_subprocess: mock.Magi
 )
 @mock.patch("jobbergate_agent.internals.update._fetch_upstream_version_info")
 @mock.patch("jobbergate_agent.internals.update._update_package")
-@mock.patch("jobbergate_agent.internals.update.get_distribution")
+@mock.patch("jobbergate_agent.internals.update.version")
 @mock.patch("jobbergate_agent.internals.update._need_update")
 @mock.patch("jobbergate_agent.internals.update.scheduler")
 @mock.patch("jobbergate_agent.internals.update.schedule_tasks")
@@ -127,7 +127,7 @@ async def test_self_update_agent(
     mocked_schedule_tasks: mock.MagicMock,
     mocked_scheduler: mock.MagicMock,
     mocked_need_update: mock.MagicMock,
-    mocked_get_distribution: mock.MagicMock,
+    mocked_version: mock.MagicMock,
     mocked_update_package: mock.MagicMock,
     mocked_fetch_upstream_version_info: mock.MagicMock,
     current_version: str,
@@ -139,7 +139,7 @@ async def test_self_update_agent(
     If an update is available, it is expected that the scheduler is shutdown
     and then restarted with the new version after the package update is done.
     """
-    mocked_get_distribution.return_value.version = current_version
+    mocked_version.return_value = current_version
     mocked_fetch_upstream_version_info.return_value = upstream_version
     mocked_need_update.return_value = is_update_available
     mocked_scheduler.shutdown = mock.Mock()
@@ -151,7 +151,7 @@ async def test_self_update_agent(
 
     await self_update_agent()
 
-    mocked_get_distribution.assert_called_once_with("jobbergate_agent")
+    mocked_version.assert_called_once_with("jobbergate_agent")
     mocked_fetch_upstream_version_info.assert_called_once_with()
     mocked_need_update.assert_called_once_with(current_version, upstream_version)
     if is_update_available:


### PR DESCRIPTION
#### What
Replaced deprecated `pkg_resources.get_distribution` with `importlib.metadata.version`.

#### Why
To preserve compatibility with Python 3.12.

`Task`: https://app.clickup.com/t/18022949/PENG-2248

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
