### PR TITLE
[ASP-5192] Hide less used command line options

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,6 +4,9 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 
+* Hided less used commands on the cli when backward compatibility mode is enabled [ASP-5192]
+* Added the subcommands `applications`, `job-scripts`, and `job-submissions` to backward compatibility mode
+* Marked backward compatible commands as deprecated and indicated the new alternative
 
 ## 5.2.0a0 -- 2024-04-29
 ## 5.1.0 -- 2024-04-19

--- a/jobbergate-cli/jobbergate_cli/compat.py
+++ b/jobbergate-cli/jobbergate_cli/compat.py
@@ -36,7 +36,7 @@ def add_legacy_compatible_commands(app: typer.Typer):
     # Applications
     app.command(
         name="list-applications",
-        help="replaced by: applications list",
+        help="LIST the available applications, replaced by: applications list",
         deprecated=True,
         rich_help_panel="Backward compatibility",
     )(list_applications)
@@ -80,7 +80,7 @@ def add_legacy_compatible_commands(app: typer.Typer):
     # Job Scripts
     app.command(
         name="list-job-scripts",
-        help="replaced by: job-scripts list",
+        help="LIST job scripts, replaced by: job-scripts list",
         deprecated=True,
         rich_help_panel="Backward compatibility",
     )(list_job_scripts)
@@ -92,7 +92,7 @@ def add_legacy_compatible_commands(app: typer.Typer):
     )(get_job_script)
     app.command(
         name="create-job-script",
-        help="replaced by: job-scripts render",
+        help="CREATE a job script, replaced by: job-scripts render",
         deprecated=True,
         rich_help_panel="Backward compatibility",
     )(render_job_script)
@@ -136,7 +136,7 @@ def add_legacy_compatible_commands(app: typer.Typer):
     # Job Submissions
     app.command(
         name="list-job-submissions",
-        help="replaced by: job-submissions list",
+        help="LIST job submissions, replaced by: job-submissions list",
         deprecated=True,
         rich_help_panel="Backward compatibility",
     )(list_job_submissions)
@@ -148,7 +148,7 @@ def add_legacy_compatible_commands(app: typer.Typer):
     )(get_job_submission)
     app.command(
         name="create-job-submission",
-        help="replaced by: job-submissions create",
+        help="CREATE a job submission, replaced by: job-submissions create",
         deprecated=True,
         rich_help_panel="Backward compatibility",
     )(create_job_submission)

--- a/jobbergate-cli/jobbergate_cli/compat.py
+++ b/jobbergate-cli/jobbergate_cli/compat.py
@@ -36,85 +36,125 @@ def add_legacy_compatible_commands(app: typer.Typer):
     # Applications
     app.command(
         name="list-applications",
-        help="LIST the available applications",
+        help="replaced by: applications list",
+        deprecated=True,
+        rich_help_panel="Backward compatibility",
     )(list_applications)
     app.command(
         name="get-application",
         help="GET an Application.",
+        deprecated=True,
+        hidden=True,
     )(get_application)
     app.command(
         name="create-application",
         help="CREATE an Application.",
+        deprecated=True,
+        hidden=True,
     )(create_application)
     app.command(
         name="delete-application",
         help="DELETE an Application.",
+        deprecated=True,
+        hidden=True,
     )(delete_application)
     app.command(
         name="update-application",
         help="UPDATE an Application.",
+        deprecated=True,
+        hidden=True,
     )(update_application)
     app.command(
         name="download-application",
         help="Download application files.",
+        deprecated=True,
+        hidden=True,
     )(download_files_application)
     app.command(
         name="clone-application",
         help="Clone an application.",
+        deprecated=True,
+        hidden=True,
     )(clone_application)
 
     # Job Scripts
     app.command(
         name="list-job-scripts",
-        help="LIST job scripts",
+        help="replaced by: job-scripts list",
+        deprecated=True,
+        rich_help_panel="Backward compatibility",
     )(list_job_scripts)
     app.command(
         name="get-job-script",
         help="GET a job script",
+        deprecated=True,
+        hidden=True,
     )(get_job_script)
     app.command(
         name="create-job-script",
-        help="CREATE a job script",
+        help="replaced by: job-scripts render",
+        deprecated=True,
+        rich_help_panel="Backward compatibility",
     )(render_job_script)
     app.command(
         name="update-job-script",
         help="UPDATE a job script",
+        deprecated=True,
+        hidden=True,
     )(update_job_script)
     app.command(
         name="render-job-script-locally",
         help="Render a job script locally",
+        deprecated=True,
+        hidden=True,
     )(render_job_script_locally)
     app.command(
         name="delete-job-script",
         help="DELETE a job script",
+        deprecated=True,
+        hidden=True,
     )(delete_job_script)
     app.command(
         name="download-job-script",
         help="Download job script files.",
+        deprecated=True,
+        hidden=True,
     )(download_files_job_script)
     app.command(
         name="show-job-script-files",
         help="Show job script files.",
+        deprecated=True,
+        hidden=True,
     )(show_files)
     app.command(
         name="clone-job-script",
         help="Clone a job script.",
+        deprecated=True,
+        hidden=True,
     )(clone_job_script)
 
     # Job Submissions
     app.command(
         name="list-job-submissions",
-        help="LIST job submissions",
+        help="replaced by: job-submissions list",
+        deprecated=True,
+        rich_help_panel="Backward compatibility",
     )(list_job_submissions)
     app.command(
         name="get-job-submission",
         help="GET a job submission",
+        deprecated=True,
+        hidden=True,
     )(get_job_submission)
     app.command(
         name="create-job-submission",
-        help="CREATE a job submission",
+        help="replaced by: job-submissions create",
+        deprecated=True,
+        rich_help_panel="Backward compatibility",
     )(create_job_submission)
     app.command(
         name="delete-job-submission",
         help="DELETE a job submission",
+        deprecated=True,
+        hidden=True,
     )(delete_job_submission)

--- a/jobbergate-cli/jobbergate_cli/main.py
+++ b/jobbergate-cli/jobbergate_cli/main.py
@@ -15,6 +15,9 @@ from jobbergate_cli.exceptions import Abort, handle_abort
 from jobbergate_cli.logging import init_logs, init_sentry
 from jobbergate_cli.render import render_json, terminal_message
 from jobbergate_cli.schemas import JobbergateContext, Persona, TokenSet
+from jobbergate_cli.subapps.applications.app import app as applications_app
+from jobbergate_cli.subapps.job_scripts.app import app as job_scripts_app
+from jobbergate_cli.subapps.job_submissions.app import app as job_submissions_app
 from jobbergate_cli.text_tools import conjoin, copy_to_clipboard
 
 
@@ -26,14 +29,10 @@ if settings.JOBBERGATE_COMPATIBILITY_MODE:
     from jobbergate_cli.compat import add_legacy_compatible_commands
 
     add_legacy_compatible_commands(app)
-else:
-    from jobbergate_cli.subapps.applications.app import app as applications_app
-    from jobbergate_cli.subapps.job_scripts.app import app as job_scripts_app
-    from jobbergate_cli.subapps.job_submissions.app import app as job_submissions_app
 
-    app.add_typer(applications_app, name="applications")
-    app.add_typer(job_scripts_app, name="job-scripts")
-    app.add_typer(job_submissions_app, name="job-submissions")
+app.add_typer(applications_app, name="applications")
+app.add_typer(job_scripts_app, name="job-scripts")
+app.add_typer(job_submissions_app, name="job-submissions")
 
 
 @app.callback(invoke_without_command=True)
@@ -101,7 +100,7 @@ def main(
     ctx.obj = context
 
 
-@app.command()
+@app.command(rich_help_panel="Authentication")
 @handle_abort
 def login(ctx: typer.Context):
     """
@@ -115,7 +114,7 @@ def login(ctx: typer.Context):
     )
 
 
-@app.command()
+@app.command(rich_help_panel="Authentication")
 @handle_abort
 def logout():
     """
@@ -128,7 +127,7 @@ def logout():
     )
 
 
-@app.command()
+@app.command(rich_help_panel="Authentication")
 @handle_abort
 def show_token(
     plain: bool = typer.Option(


### PR DESCRIPTION
#### What
* Hide less used commands on the help text when backward compatibility mode is enabled
* Add the subcommands `applications`, `job-scripts`, and `job-submissions` to backward compatibility mode
* Signalize backward compatible commands are deprecated and indicate the new alternative

See the resulting help text:

![image](https://github.com/omnivector-solutions/jobbergate/assets/37457501/80632af3-9960-4ba6-97a4-5c8de8276d25)


#### Why
Users will be less confused by the amount of command options available to them.

`Task`: https://jira.scania.com/browse/ASP-5192

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
