### PR TITLE
fix(cli): sort_order on list commands

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
-
+* Fixed parameter `--sort-order` on the listing commands
 
 ## 5.2.0a2 -- 2024-05-31
 ## 5.2.0a1 -- 2024-05-24

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/app.py
@@ -83,7 +83,7 @@ def list_all(
     if search is not None:
         params["search"] = search
     if sort_order is not SortOrder.UNSORTED:
-        params["sort_ascending"] = SortOrder is SortOrder.ASCENDING
+        params["sort_ascending"] = sort_order is SortOrder.ASCENDING
     if sort_field is not None:
         params["sort_field"] = sort_field
 

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -74,7 +74,7 @@ def list_all(
     if search is not None:
         params["search"] = search
     if sort_order is not SortOrder.UNSORTED:
-        params["sort_ascending"] = SortOrder is SortOrder.ASCENDING
+        params["sort_ascending"] = sort_order is SortOrder.ASCENDING
     if sort_field is not None:
         params["sort_field"] = sort_field
     if from_application_id is not None:

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -152,7 +152,7 @@ def list_all(
     if search is not None:
         params["search"] = search
     if sort_order is not SortOrder.UNSORTED:
-        params["sort_ascending"] = SortOrder is SortOrder.ASCENDING
+        params["sort_ascending"] = sort_order is SortOrder.ASCENDING
     if sort_field is not None:
         params["sort_field"] = sort_field
     if from_job_script_id is not None:


### PR DESCRIPTION
#### What
Fix the `sort_order` on the three list commands

#### Why
Fix fix


---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
