### PR TITLE
PENG-2230 remove the audience setting from the API project

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -4,8 +4,10 @@ This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
 
+- Remove the audience setting [[PENG-2230](https://sharing.clickup.com/t/h/c/18022949/PENG-2230/O40JANAF6KCBE9R)]
 
 ## 5.2.0 -- 2024-07-01
+
 - Fixed issue when retrieving large files on get routes after upgrading to FastAPI 0.111
 - Change pydantic.BaseSettings config to use `extra=ignore`
 - Migrated to Pydantic version 2 [PENG-2277]

--- a/jobbergate-api/jobbergate_api/config.py
+++ b/jobbergate-api/jobbergate_api/config.py
@@ -79,10 +79,8 @@ class Settings(BaseSettings):
     # Security Settings. For details, see https://github.com/omnivector-solutions/armasec
     ARMASEC_DOMAIN: str
     ARMASEC_USE_HTTPS: bool = Field(True)
-    ARMASEC_AUDIENCE: Optional[str] = None
     ARMASEC_DEBUG: bool = Field(False)
     ARMASEC_ADMIN_DOMAIN: Optional[str] = None
-    ARMASEC_ADMIN_AUDIENCE: Optional[str] = None
     ARMASEC_ADMIN_MATCH_KEY: Optional[str] = None
     ARMASEC_ADMIN_MATCH_VALUE: Optional[str] = None
 

--- a/jobbergate-api/jobbergate_api/security.py
+++ b/jobbergate-api/jobbergate_api/security.py
@@ -25,14 +25,12 @@ def get_domain_configs() -> list[DomainConfig]:
     domain_configs = [
         DomainConfig(
             domain=settings.ARMASEC_DOMAIN,
-            audience=settings.ARMASEC_AUDIENCE,
             use_https=settings.ARMASEC_USE_HTTPS,
         )
     ]
     if all(
         [
             settings.ARMASEC_ADMIN_DOMAIN,
-            settings.ARMASEC_ADMIN_AUDIENCE,
             settings.ARMASEC_ADMIN_MATCH_KEY,
             settings.ARMASEC_ADMIN_MATCH_VALUE,
         ]
@@ -45,7 +43,6 @@ def get_domain_configs() -> list[DomainConfig]:
         domain_configs.append(
             DomainConfig(
                 domain=settings.ARMASEC_ADMIN_DOMAIN,
-                audience=settings.ARMASEC_ADMIN_AUDIENCE,
                 use_https=settings.ARMASEC_USE_HTTPS,
                 match_keys={settings.ARMASEC_ADMIN_MATCH_KEY: settings.ARMASEC_ADMIN_MATCH_VALUE},
             )

--- a/jobbergate-api/tests/test_security.py
+++ b/jobbergate-api/tests/test_security.py
@@ -20,21 +20,18 @@ def test_get_domain_configs__loads_only_base_settings():
     """Check if the correct domain configuration is loaded when only one domain is provided."""
     with (
         patch.object(settings, "ARMASEC_DOMAIN", new="foo.io"),
-        patch.object(settings, "ARMASEC_AUDIENCE", new="https://bar.dev"),
     ):
         domain_configs = get_domain_configs()
 
     assert len(domain_configs) == 1
     first_config = domain_configs.pop()
     assert first_config.domain == "foo.io"
-    assert first_config.audience == "https://bar.dev"
 
 
 def test_get_domain_configs__loads_admin_settings_if_all_are_present():
     """Check if the correct domain configuration is loaded when two domains are provided."""
     with (
         patch.object(settings, "ARMASEC_DOMAIN", new="foo.io"),
-        patch.object(settings, "ARMASEC_AUDIENCE", new="https://bar.dev"),
         patch.object(settings, "ARMASEC_ADMIN_DOMAIN", new="admin.io"),
     ):
         domain_configs = get_domain_configs()
@@ -42,13 +39,10 @@ def test_get_domain_configs__loads_admin_settings_if_all_are_present():
     assert len(domain_configs) == 1
     first_config = domain_configs.pop()
     assert first_config.domain == "foo.io"
-    assert first_config.audience == "https://bar.dev"
 
     with (
         patch.object(settings, "ARMASEC_DOMAIN", new="foo.io"),
-        patch.object(settings, "ARMASEC_AUDIENCE", new="https://bar.dev"),
         patch.object(settings, "ARMASEC_ADMIN_DOMAIN", new="admin.io"),
-        patch.object(settings, "ARMASEC_ADMIN_AUDIENCE", new="https://admin.dev"),
         patch.object(settings, "ARMASEC_ADMIN_MATCH_KEY", new="foo"),
         patch.object(settings, "ARMASEC_ADMIN_MATCH_VALUE", new="bar"),
     ):
@@ -57,9 +51,7 @@ def test_get_domain_configs__loads_admin_settings_if_all_are_present():
     assert len(domain_configs) == 2
     (first_config, second_config) = domain_configs
     assert first_config.domain == "foo.io"
-    assert first_config.audience == "https://bar.dev"
     assert second_config.domain == "admin.io"
-    assert second_config.audience == "https://admin.dev"
     assert second_config.match_keys == dict(foo="bar")
 
 

--- a/jobbergate-docs/docs/source/developer_guide/dev_tools.md
+++ b/jobbergate-docs/docs/source/developer_guide/dev_tools.md
@@ -173,10 +173,8 @@ Jobbergate settings:
   S3_ENDPOINT_URL: None
   ARMASEC_DOMAIN: localhost:9080/realms/master/protocol/openid-connect
   ARMASEC_USE_HTTPS: True
-  ARMASEC_AUDIENCE: https://local.omnivector.solutions
   ARMASEC_DEBUG: True
   ARMASEC_ADMIN_DOMAIN: None
-  ARMASEC_ADMIN_AUDIENCE: None
   ARMASEC_ADMIN_MATCH_KEY: None
   ARMASEC_ADMIN_MATCH_VALUE: None
   IDENTITY_CLAIMS_KEY: https://omnivector.solutions
@@ -196,7 +194,7 @@ poetry run dev-tools show-env --json
 The JSON output will look something like:
 
 ```json
-{"DEPLOY_ENV": "LOCAL", "LOG_LEVEL": "DEBUG", "DATABASE_HOST": "localhost", "DATABASE_USER": "compose-db-user", "DATABASE_PSWD": "compose-db-pswd", "DATABASE_NAME": "compose-db-name", "DATABASE_PORT": 5432, "TEST_DATABASE_HOST": "localhost", "TEST_DATABASE_USER": "test-user", "TEST_DATABASE_PSWD": "test-pswd", "TEST_DATABASE_NAME": "test-db", "TEST_DATABASE_PORT": 5433, "S3_BUCKET_NAME": "jobbergate-k8s-staging", "S3_ENDPOINT_URL": null, "ARMASEC_DOMAIN": "localhost:9080/realms/master/protocol/openid-connect", "ARMASEC_USE_HTTPS": true, "ARMASEC_AUDIENCE": "https://local.omnivector.solutions", "ARMASEC_DEBUG": true, "ARMASEC_ADMIN_DOMAIN": null, "ARMASEC_ADMIN_AUDIENCE": null, "ARMASEC_ADMIN_MATCH_KEY": null, "ARMASEC_ADMIN_MATCH_VALUE": null, "IDENTITY_CLAIMS_KEY": "https://omnivector.solutions", "SENTRY_DSN": null, "SENTRY_SAMPLE_RATE": 1.0, "MAX_UPLOAD_FILE_SIZE": 104857600, "SENDGRID_FROM_EMAIL": null, "SENDGRID_API_KEY": null}
+{"DEPLOY_ENV": "LOCAL", "LOG_LEVEL": "DEBUG", "DATABASE_HOST": "localhost", "DATABASE_USER": "compose-db-user", "DATABASE_PSWD": "compose-db-pswd", "DATABASE_NAME": "compose-db-name", "DATABASE_PORT": 5432, "TEST_DATABASE_HOST": "localhost", "TEST_DATABASE_USER": "test-user", "TEST_DATABASE_PSWD": "test-pswd", "TEST_DATABASE_NAME": "test-db", "TEST_DATABASE_PORT": 5433, "S3_BUCKET_NAME": "jobbergate-k8s-staging", "S3_ENDPOINT_URL": null, "ARMASEC_DOMAIN": "localhost:9080/realms/master/protocol/openid-connect", "ARMASEC_USE_HTTPS": true, "ARMASEC_DEBUG": true, "ARMASEC_ADMIN_DOMAIN": null, "ARMASEC_ADMIN_MATCH_KEY": null, "ARMASEC_ADMIN_MATCH_VALUE": null, "IDENTITY_CLAIMS_KEY": "https://omnivector.solutions", "SENTRY_DSN": null, "SENTRY_SAMPLE_RATE": 1.0, "MAX_UPLOAD_FILE_SIZE": 104857600, "SENDGRID_FROM_EMAIL": null, "SENDGRID_API_KEY": null}
 ```
 
 ## The `dev-server` subcommand

--- a/jobbergate-docs/docs/source/developer_guide/keycloak_setup.md
+++ b/jobbergate-docs/docs/source/developer_guide/keycloak_setup.md
@@ -83,12 +83,6 @@ Jobbergate requires two claims that are not available by default. We will add th
 
 Click the `Mappers`  tab at the top, and then click the `Create` button to add a new Mapper.
 
-#### Audience
-
-First, we need to add an "audience" mapper. Select "audience" for the `Name` field. Next, select "Audience" for the
-`Mapper Type`.  The `Included Custom Audience` value may be whatever you like. The local deploy, by default, uses
-<https://apis.omnivector.solutions>. Make sure to enable the `Add to ID token` setting.
-
 #### Permissions
 
 The `Armasec` package expects to find "permissions" in a claim at the root
@@ -127,15 +121,9 @@ Click on the `Roles` tab, and click the `Add Role` button. Add all the following
 
 ### Add Mappers
 
-Like the CLI client, the Agent's client also requires the "Audience" and "Permissions" mappers.
+Like the CLI client, the Agent's client also requires the "Permissions" mapper.
 
 Click the `Mappers`  tab at the top, and then click the `Create` button to add a new Mapper.
-
-#### Audience
-
-First, we need to add an "audience" mapper. Select "audience" for the `Name` field. Next, select "Audience" for the
-`Mapper Type`.  The `Included Custom Audience` value may be whatever you like. The local deploy, by default, uses
-"<https://apis.omnivector.solutions>". Make sure to enable the `Add to ID token` setting.
 
 #### Permissions
 


### PR DESCRIPTION
#### What
This PR only removes the audience setting from the settings class of the API.

#### Why
This is a deprecated feature we used some time ago and it makes no sense anymore to keep it.

`Task`: https://sharing.clickup.com/t/h/c/18022949/PENG-2230/O40JANAF6KCBE9R

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
