### PR TITLE
[ASP-5192] Implementation: Hide less used command line options

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -10,6 +10,10 @@ This file keeps track of all notable changes to jobbergate-cli
   - Added pydantic-settings 2.3.3
 - Fixed parameter `--sort-order` on the listing commands
 - Updated linter and format checker to use ruff
+- Added a quick start guide to be displayed when the user runs the command with no arguments and after login
+- Renamed command `jobbergate job-scripts create` to `jobbergate job-scripts create-stand-alone`
+- Renamed command `jobbergate job-scripts render` to `jobbergate job-scripts create`
+- Renamed command `jobbergate job-scripts render-locally` to `jobbergate job-scripts create-locally`
 
 ## 5.2.0a2 -- 2024-05-31
 

--- a/jobbergate-cli/jobbergate_cli/compat.py
+++ b/jobbergate-cli/jobbergate_cli/compat.py
@@ -13,12 +13,12 @@ from jobbergate_cli.subapps.applications.app import get_one as get_application
 from jobbergate_cli.subapps.applications.app import list_all as list_applications
 from jobbergate_cli.subapps.applications.app import update as update_application
 from jobbergate_cli.subapps.job_scripts.app import clone as clone_job_script
+from jobbergate_cli.subapps.job_scripts.app import create as create_job_script
+from jobbergate_cli.subapps.job_scripts.app import create_locally as create_job_script_locally
 from jobbergate_cli.subapps.job_scripts.app import delete as delete_job_script
 from jobbergate_cli.subapps.job_scripts.app import download_files as download_files_job_script
 from jobbergate_cli.subapps.job_scripts.app import get_one as get_job_script
 from jobbergate_cli.subapps.job_scripts.app import list_all as list_job_scripts
-from jobbergate_cli.subapps.job_scripts.app import render as render_job_script
-from jobbergate_cli.subapps.job_scripts.app import render_locally as render_job_script_locally
 from jobbergate_cli.subapps.job_scripts.app import show_files as show_files
 from jobbergate_cli.subapps.job_scripts.app import update as update_job_script
 from jobbergate_cli.subapps.job_submissions.app import create as create_job_submission
@@ -92,10 +92,10 @@ def add_legacy_compatible_commands(app: typer.Typer):
     )(get_job_script)
     app.command(
         name="create-job-script",
-        help="CREATE a job script, replaced by: job-scripts render",
+        help="CREATE a job script, replaced by: job-scripts create",
         deprecated=True,
         rich_help_panel="Backward compatibility",
-    )(render_job_script)
+    )(create_job_script)
     app.command(
         name="update-job-script",
         help="UPDATE a job script",
@@ -104,10 +104,10 @@ def add_legacy_compatible_commands(app: typer.Typer):
     )(update_job_script)
     app.command(
         name="render-job-script-locally",
-        help="Render a job script locally",
+        help="Render a job script locally, replaced by: job-scripts create-locally",
         deprecated=True,
         hidden=True,
-    )(render_job_script_locally)
+    )(create_job_script_locally)
     app.command(
         name="delete-job-script",
         help="DELETE a job script",

--- a/jobbergate-cli/jobbergate_cli/main.py
+++ b/jobbergate-cli/jobbergate_cli/main.py
@@ -9,17 +9,17 @@ import importlib_metadata
 import jose
 import typer
 
+
 from jobbergate_cli.auth import clear_token_cache, fetch_auth_tokens, init_persona, load_tokens_from_cache
 from jobbergate_cli.config import settings
 from jobbergate_cli.exceptions import Abort, handle_abort
 from jobbergate_cli.logging import init_logs, init_sentry
-from jobbergate_cli.render import render_json, terminal_message
+from jobbergate_cli.render import render_demo, render_json, terminal_message
 from jobbergate_cli.schemas import JobbergateContext, Persona, TokenSet
 from jobbergate_cli.subapps.applications.app import app as applications_app
 from jobbergate_cli.subapps.job_scripts.app import app as job_scripts_app
 from jobbergate_cli.subapps.job_submissions.app import app as job_submissions_app
-from jobbergate_cli.text_tools import conjoin, copy_to_clipboard
-
+from jobbergate_cli.text_tools import copy_to_clipboard
 
 app = typer.Typer()
 
@@ -63,14 +63,7 @@ def main(
         raise typer.Exit()
 
     if ctx.invoked_subcommand is None:
-        terminal_message(
-            conjoin(
-                "No command provided. Please check the [bold magenta]usage[/bold magenta] and add a command",
-                "",
-                f"[yellow]{ctx.get_help()}[/yellow]",
-            ),
-            subject="Need a jobbergate command",
-        )
+        render_demo(pre_amble="No command provided.")
         raise typer.Exit()
 
     init_logs(verbose=verbose)

--- a/jobbergate-cli/jobbergate_cli/main.py
+++ b/jobbergate-cli/jobbergate_cli/main.py
@@ -105,6 +105,7 @@ def login(ctx: typer.Context):
         f"User was logged in with email '{persona.identity_data.email}'",
         subject="Logged in!",
     )
+    render_demo()
 
 
 @app.command(rich_help_panel="Authentication")

--- a/jobbergate-cli/jobbergate_cli/render.py
+++ b/jobbergate-cli/jobbergate_cli/render.py
@@ -263,9 +263,7 @@ def render_demo(pre_amble: str | None = None):
     """
     message = dedent(
         """       
-        Here is a quick start on the Jobbergate CLI:
-
-        * To created a job-script and run it on the cluster, run the command:
+        * To create a job-script and run it on the cluster, run the command:
 
           ```jobbergate job-scripts create --application-identifier <value>```
 
@@ -277,9 +275,9 @@ def render_demo(pre_amble: str | None = None):
 
            ```jobbergate applications list --search <search-term>```
 
-        * For more information on any command, run it with the `--help` option.
+        * For more information on any command run it with the `--help` option.
 
-        * To check all the available commands, run:
+        * To check all the available commands refer to:
 
           ```jobbergate --help```
         """
@@ -288,5 +286,5 @@ def render_demo(pre_amble: str | None = None):
     if pre_amble:
         console.print(pre_amble)
     console.print()
-    console.print(Panel(Markdown(message), title="Welcome to Jobbergate CLI"))
+    console.print(Panel(Markdown(message), title="Quick Start Guide on Jobbergate-CLI"))
     console.print()

--- a/jobbergate-cli/jobbergate_cli/render.py
+++ b/jobbergate-cli/jobbergate_cli/render.py
@@ -263,11 +263,11 @@ def render_demo(pre_amble: str | None = None):
     """
     message = dedent(
         """       
-        * To create a job-script and run it on the cluster, run the command:
+        * To create a job-script and run it on the cluster, use the command:
 
           ```jobbergate job-scripts create --application-identifier <value>```
 
-        * In case you need to find your application identifier, run the command:
+        * If you need to find your application identifier, run the command:
 
            ```jobbergate applications list```
 
@@ -277,7 +277,7 @@ def render_demo(pre_amble: str | None = None):
 
         * For more information on any command run it with the `--help` option.
 
-        * To check all the available commands refer to:
+        * To check all the available commands, refer to:
 
           ```jobbergate --help```
         """
@@ -286,5 +286,5 @@ def render_demo(pre_amble: str | None = None):
     if pre_amble:
         console.print(pre_amble)
     console.print()
-    console.print(Panel(Markdown(message), title="Quick Start Guide on Jobbergate-CLI"))
+    console.print(Panel(Markdown(message), title="Quick Start Guide for Jobbergate-CLI"))
     console.print()

--- a/jobbergate-cli/jobbergate_cli/render.py
+++ b/jobbergate-cli/jobbergate_cli/render.py
@@ -10,6 +10,7 @@ from rich import print_json
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from rich.markdown import Markdown
 
 from jobbergate_cli.schemas import JobbergateContext, ListResponseEnvelope
 from jobbergate_cli.text_tools import dedent
@@ -254,3 +255,38 @@ def render_paginated_list_results(
     console = Console()
     console.print()
     console.print(table)
+
+
+def render_demo(pre_amble: str | None = None):
+    """
+    Show the demo for the jobbergate-cli.
+    """
+    message = dedent(
+        """       
+        Here is a quick start on the Jobbergate CLI:
+
+        * To created a job-script and run it on the cluster, run the command:
+
+          ```jobbergate job-scripts create --application-identifier <value>```
+
+        * In case you need to find your application identifier, run the command:
+
+           ```jobbergate applications list```
+
+           Or search for an application by name:
+
+           ```jobbergate applications list --search <search-term>```
+
+        * For more information on any command, run it with the `--help` option.
+
+        * To check all the available commands, run:
+
+          ```jobbergate --help```
+        """
+    )
+    console = Console()
+    if pre_amble:
+        console.print(pre_amble)
+    console.print()
+    console.print(Panel(Markdown(message), title="Welcome to Jobbergate CLI"))
+    console.print()

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -113,7 +113,7 @@ def get_one(
 
 @app.command()
 @handle_abort
-def create(
+def create_stand_alone(
     ctx: typer.Context,
     name: str = typer.Option(
         ...,
@@ -129,6 +129,9 @@ def create(
         help="A path for one of the supporting files to upload",
     ),
 ):
+    """
+    Create and upload files for a standalone job script (i.e., unrelated to any application).
+    """
     jg_ctx: JobbergateContext = ctx.obj
 
     # Make static type checkers happy
@@ -165,7 +168,7 @@ def create(
 
 @app.command()
 @handle_abort
-def render_locally(
+def create_locally(
     ctx: typer.Context,
     application_path: pathlib.Path = typer.Argument(
         pathlib.Path("."),
@@ -202,7 +205,7 @@ def render_locally(
     ),
 ):
     """
-    Render a new job-script from an application locally.
+    Create a job-script from local application files (ideal for development and troubleshooting).
 
     The templates will be overwritten with the rendered files.
     """
@@ -226,7 +229,7 @@ def render_locally(
 
 @app.command()
 @handle_abort
-def render(
+def create(
     ctx: typer.Context,
     name: Optional[str] = typer.Option(
         None,
@@ -297,7 +300,7 @@ def render(
     ),
 ):
     """
-    Render a new job script from an application.
+    Create a new job script from an application.
     """
     jg_ctx: JobbergateContext = ctx.obj
 


### PR DESCRIPTION
#### What

- Added a quick start guide to be displayed when the user runs the command with no arguments and after login

- Notice the fact `jobbergate create-job-script` was equivalent to `jobbergate job-script render` instead of `jobbergate job-script create` was identified as a possible point of confusion for end-users, so the following was also applyed:

  - Renamed command `jobbergate job-scripts create` to `jobbergate job-scripts create-stand-alone`
  - Renamed command `jobbergate job-scripts render` to `jobbergate job-scripts create`
  - Renamed command `jobbergate job-scripts render-locally` to `jobbergate job-scripts create-locally`

#### Why
Solving feedback commants after acceptance tests

`Task`: https://jira.scania.com/browse/ASP-5192

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
