### PR TITLE
fix(cli): ApplicationRuntime filling supporting files when they are set as empty list

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -14,6 +14,7 @@ This file keeps track of all notable changes to jobbergate-cli
 - Renamed command `jobbergate job-scripts create` to `jobbergate job-scripts create-stand-alone`
 - Renamed command `jobbergate job-scripts render` to `jobbergate job-scripts create`
 - Renamed command `jobbergate job-scripts render-locally` to `jobbergate job-scripts create-locally`
+- Fixed `ApplicationRuntime` filling supporting files when they are already set by the application as an empty list
 
 ## 5.2.0a2 -- 2024-05-31
 

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/tools.py
@@ -540,7 +540,7 @@ class ApplicationRuntime:
                 )
             self.app_config.jobbergate_config.default_template = list_of_entrypoints[0]
 
-        if not self.app_config.jobbergate_config.supporting_files:
+        if self.app_config.jobbergate_config.supporting_files is None:
             list_of_supporting_files = [
                 i.filename for i in self.app_data.template_files if i.file_type.upper() == "SUPPORT"
             ]


### PR DESCRIPTION
#### What
* `ApplicationRuntime` filling supporting files when they are set as empty list

#### Why
* There is no need to fill them in if the application already set them as an empty list, but just when they are `None`.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
