### PR TITLE
Change pydantic.BaseSettings config to use `extra=ignore`

### DIFF
--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to jobbergate-agent
 
 ## Unreleased
-
+- Change pydantic.BaseSettings config to use `extra=ignore`
 
 ## 5.2.0a3 -- 2024-06-26
 - Migrated to Pydantic version 2 [PENG-2278]

--- a/jobbergate-agent/jobbergate_agent/settings.py
+++ b/jobbergate-agent/jobbergate_agent/settings.py
@@ -82,10 +82,7 @@ class Settings(BaseSettings):
             self.SINGLE_USER_SUBMITTER = self.X_SLURM_USER_NAME
         return self
 
-    model_config = SettingsConfigDict(
-        env_prefix="JOBBERGATE_AGENT_",
-        env_file=_get_env_file(),
-    )
+    model_config = SettingsConfigDict(env_prefix="JOBBERGATE_AGENT_", env_file=_get_env_file(), extra="ignore")
 
 
 def init_settings() -> Settings:

--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
-
+- Change pydantic.BaseSettings config to use `extra=ignore`
 
 ## 5.2.0a3 -- 2024-06-26
 - Migrated to Pydantic version 2 [PENG-2277]

--- a/jobbergate-api/jobbergate_api/config.py
+++ b/jobbergate-api/jobbergate_api/config.py
@@ -139,7 +139,7 @@ class Settings(BaseSettings):
 
         return clean_values
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 
 settings = Settings()

--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
-
+- Change pydantic.BaseSettings config to use `extra=ignore`
 
 ## 5.2.0a3 -- 2024-06-26
 - Migrated to Pydantic version 2 [PENG-2279]

--- a/jobbergate-cli/jobbergate_cli/config.py
+++ b/jobbergate-cli/jobbergate_cli/config.py
@@ -115,9 +115,7 @@ class Settings(BaseSettings):
         """Check if the SBATCH_PATH is set, indicating that the CLI is running in on-site mode."""
         return self.SBATCH_PATH is not None
 
-    model_config = SettingsConfigDict(
-        env_file=_get_env_file(),
-    )
+    model_config = SettingsConfigDict(env_file=_get_env_file(), extra="ignore")
 
 
 def build_settings(*args, **kwargs):


### PR DESCRIPTION
#### What
Change `pydantic.BaseSettings` config to use `extra=ignore`.

#### Why
Make the system more robust in case it faces any leftover configuration on uptade, or if any plugin uses the same environment prefix.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
