### PR TITLE
PENG-2348 implement an endpoint to get a cluster's status by the client_id

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -10,6 +10,7 @@ This file keeps track of all notable changes to jobbergate-api
 - Added `jobbergate:maintainer` role [[PENG-2323](https://app.clickup.com/t/18022949/PENG-2323)]
     - `jobbergate:maintainer` acts as previous `jobbergate:admin` role, allowing users to update/delete entities owned by others
     - `jobbergate:admin` now grants access to all endpoints besides the `jobbergate:maintainer` role
+- Implemented an endpoint to fetch a cluster status by its client id [[PENG-2348](https://sharing.clickup.com/t/h/c/18022949/PENG-2348/QWZFBKV72ZNL293)]
 
 ## 5.2.0 -- 2024-07-01
 

--- a/jobbergate-api/jobbergate_api/apps/clusters/routers.py
+++ b/jobbergate-api/jobbergate_api/apps/clusters/routers.py
@@ -84,4 +84,4 @@ async def get_cluster_status_by_client_id(
     instance = result.scalar_one_or_none()
     if instance is None:
         return FastAPIResponse(status_code=status.HTTP_404_NOT_FOUND)
-    return ClusterStatusView.model_validate(instance)
+    return instance

--- a/jobbergate-api/tests/apps/clusters/test_routers.py
+++ b/jobbergate-api/tests/apps/clusters/test_routers.py
@@ -129,20 +129,22 @@ class TestListClusterStatus:
 
 class TestGetClusterStatus:
     @pytest.mark.parametrize("permission", (Permissions.ADMIN, Permissions.CLUSTERS_READ))
-    @pytest.mark.parametrize("client_id", ("client-1", "client-2", "client-3"))
     async def test_get_cluster_status_by_client_id__not_found(
-        self, permission, client_id, client, inject_security_header, synth_session
+        self, permission, client, inject_security_header, synth_session
     ):
+        client_id = "dummy-client"
+
         inject_security_header("who@cares.com", permission)
 
         response = await client.get(f"/jobbergate/clusters/status/{client_id}")
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.parametrize("permission", (Permissions.ADMIN, Permissions.CLUSTERS_READ))
-    @pytest.mark.parametrize("client_id", ("client-1", "client-2", "client-3"))
     async def test_get_cluster_status_by_client_id__found(
-        self, permission, client_id, client, inject_security_header, synth_session
+        self, permission, client, inject_security_header, synth_session
     ):
+        client_id = "dummy-client"
+
         inject_security_header("who@cares.com", permission)
 
         cluster_status = ClusterStatus(


### PR DESCRIPTION
#### What
This PR implement an endpoint for fetching a cluster's status by passing the `client_id` parameter in the path of the request.

#### Why
Necessary to enhance the API consumers performance when querying specific clusters' statuses.

`Task`: https://sharing.clickup.com/t/h/c/18022949/PENG-2348/QWZFBKV72ZNL293

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
