### PR TITLE
Review keycloak settings on jobbergate-composed

### DIFF
--- a/jobbergate-composed/etc/jobbergate-local.json
+++ b/jobbergate-composed/etc/jobbergate-local.json
@@ -1025,19 +1025,18 @@
           "consentRequired": false,
           "config": {
             "id.token.claim": "true",
-            "access.token.claim": "true",
-            "included.custom.audience": "https://local.omnivector.solutions"
+            "access.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
-        "web-origins",
-        "acr",
         "profile",
-        "roles",
         "email"
       ],
       "optionalClientScopes": [
+        "acr",
+        "web-origins",
+        "roles",
         "address",
         "phone",
         "offline_access",
@@ -1122,19 +1121,18 @@
           "config": {
             "id.token.claim": "true",
             "access.token.claim": "true",
-            "included.custom.audience": "https://local.omnivector.solutions",
             "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
-        "web-origins",
-        "acr",
         "profile",
-        "roles",
         "email"
       ],
       "optionalClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
         "address",
         "phone",
         "offline_access",


### PR DESCRIPTION
#### What
- Review client scopes on keycloak to remove the field `aud`.

#### Why
- All requests were resulting in 401 Unauthorized since https://github.com/omnivector-solutions/jobbergate/pull/571 was merged.



---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
