### PR TITLE
fix(api): enable rendering an empty template

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
-
+- Fixed issue preventing the creation of a job script from an empty template file
 
 ## 5.3.0a2 -- 2024-08-20
 - Enhance logging for file storage operations

--- a/jobbergate-api/jobbergate_api/apps/services.py
+++ b/jobbergate-api/jobbergate_api/apps/services.py
@@ -541,7 +541,7 @@ class FileService(DatabaseBoundService, BucketBoundService, Generic[FileModel]):
         if previous_filename == filename:
             previous_filename = None
 
-        if upload_content:
+        if upload_content is not None:
             await self.upload_file_content(upsert_instance, upload_content)
             if not previous_filename:
                 return upsert_instance

--- a/jobbergate-api/tests/apps/test_services.py
+++ b/jobbergate-api/tests/apps/test_services.py
@@ -674,37 +674,31 @@ class TestFileService:
         file_data = await dummy_file_service.get_file_content(upserted_instance)
         assert file_data == "dummy upload content".encode()
 
-    async def test_upsert__with_string(self, dummy_file_service):
+    @pytest.mark.parametrize("file_content", ["dummy string content", ""])
+    async def test_upsert__with_string(self, file_content, dummy_file_service):
         """
         Test that the ``upsert()`` method can create a file from a string.
         """
-        upserted_instance = await dummy_file_service.upsert(
-            13,
-            "file-one.txt",
-            "dummy string content",
-        )
+        upserted_instance = await dummy_file_service.upsert(13, "file-one.txt", file_content)
 
         assert upserted_instance.parent_id == 13
         assert upserted_instance.filename == "file-one.txt"
 
         file_data = await dummy_file_service.get_file_content(upserted_instance)
-        assert file_data == "dummy string content".encode()
+        assert file_data == file_content.encode()
 
-    async def test_upsert__with_bytes(self, dummy_file_service):
+    @pytest.mark.parametrize("file_content", [b"dummy bytes content", b""])
+    async def test_upsert__with_bytes(self, file_content, dummy_file_service):
         """
         Test that the ``upsert()`` method can create a file from bytes.
         """
-        upserted_instance = await dummy_file_service.upsert(
-            13,
-            "file-one.txt",
-            "dummy bytes content".encode(),
-        )
+        upserted_instance = await dummy_file_service.upsert(13, "file-one.txt", file_content)
 
         assert upserted_instance.parent_id == 13
         assert upserted_instance.filename == "file-one.txt"
 
         file_data = await dummy_file_service.get_file_content(upserted_instance)
-        assert file_data == "dummy bytes content".encode()
+        assert file_data == file_content
 
     @pytest.mark.parametrize(
         "filename, content",


### PR DESCRIPTION
#### What
* Enable rendering an empty template

#### Why
* Patch issue

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
