### PR TITLE
fix(agent): download files for large submission names

### DIFF
--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to jobbergate-agent
 
 ## Unreleased
-
+- Fixed issue when downloading job script files for job submission with large names
 
 ## 5.3.0a4 -- 2024-08-23
 ## 5.3.0a3 -- 2024-08-21

--- a/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
@@ -229,14 +229,12 @@ async def submit_job_script(
         subprocess_handler=subprocess_handler,
     )
 
-    with TemporaryDirectory(prefix=str(pending_job_submission.id), suffix=pending_job_submission.name) as tmp_dir:
-        tmp_dir_path = Path(tmp_dir)
-        async with handle_errors_async(
-            "Error processing job-script files",
-            raise_exc_class=JobSubmissionError,
-            do_except=_reject_handler,
-        ):
-            logger.debug(f"Processing submission files for job submission {pending_job_submission.id}")
+    async with handle_errors_async(
+        "Error processing job-script files", raise_exc_class=JobSubmissionError, do_except=_reject_handler
+    ):
+        logger.debug(f"Processing submission files for job submission {pending_job_submission.id}")
+        with TemporaryDirectory(prefix=f"jobbergate-submission-{pending_job_submission.id}-") as tmp_dir:
+            tmp_dir_path = Path(tmp_dir)
 
             supporting_files = await process_supporting_files(pending_job_submission, tmp_dir_path)
 

--- a/jobbergate-agent/tests/jobbergate/test_submit.py
+++ b/jobbergate-agent/tests/jobbergate/test_submit.py
@@ -405,8 +405,9 @@ async def test_mark_as_rejected__raises_JobbergateApiError_if_the_response_is_no
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_access_token")
+@pytest.mark.parametrize("job_submissions_name", ["dummy-job-submission", "really-long-job-submission-name" * 10])
 async def test_submit_job_script__success_with_files(
-    mocker, dummy_pending_job_submission_data, dummy_template_source, tweak_settings, user_mapper
+    mocker, job_submissions_name, dummy_pending_job_submission_data, dummy_template_source, tweak_settings, user_mapper
 ):
     """
     Test that the ``submit_job_script()`` successfully submits a job.
@@ -415,6 +416,7 @@ async def test_submit_job_script__success_with_files(
     and that a ``slurm_job_id`` is returned.
     """
     pending_job_submission = PendingJobSubmission(**dummy_pending_job_submission_data)
+    pending_job_submission.name = job_submissions_name
 
     mocked_sbatch = mock.MagicMock()
     mocked_sbatch.submit_job = lambda *args, **kwargs: 13


### PR DESCRIPTION
#### What
Patch issue.

#### Why
`TemporaryDirectory` was raising an error when the job-submissions had a large file name.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
