### PR TITLE
[PENG-2342] Jobbergate Agent continually resubmits the same job if the job status update fails

### DIFF
--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -4,6 +4,7 @@ This file keeps track of all notable changes to jobbergate-agent
 
 ## Unreleased
 - Fixed issue when downloading job script files for job submission with large names
+- Cache slurm submissions to avoid the resubmission of the same job if the job status update fails [PENG-2342]
 
 ## 5.3.0a5 -- 2024-08-30
 ## 5.3.0a4 -- 2024-08-23

--- a/jobbergate-agent/tests/jobbergate/test_submit.py
+++ b/jobbergate-agent/tests/jobbergate/test_submit.py
@@ -732,8 +732,8 @@ async def test_submit_pending_jobs(
     )
     assert mock_mark.call_count == 3
 
-    assert cached_submissions[1].exists() is False
-    assert cached_submissions[2].exists() is True
+    assert not cached_submissions[1].exists()
+    assert cached_submissions[2].exists()
     assert cached_submissions[2].read_text() == "22"
-    assert cached_submissions[3].exists() is False
-    assert cached_submissions[4].exists() is False
+    assert not cached_submissions[3].exists()
+    assert not cached_submissions[4].exists()

--- a/jobbergate-agent/tests/jobbergate/test_submit.py
+++ b/jobbergate-agent/tests/jobbergate/test_submit.py
@@ -710,8 +710,8 @@ async def test_submit_pending_jobs(
     test_mapper = manufacture()
 
     with tweak_settings(CACHE_DIR=tmp_path):
-        cached_submission_4 = tmp_path / "4.slurm_job_id"
-        cached_submission_4.write_text("44")
+        cached_submissions = {sub.id: tmp_path / f"{sub.id}.slurm_job_id" for sub in pending_submissions}
+        cached_submissions[4].write_text("44")
         await submit_pending_jobs()
 
     mock_submit.assert_has_calls(
@@ -732,4 +732,8 @@ async def test_submit_pending_jobs(
     )
     assert mock_mark.call_count == 3
 
-    assert cached_submission_4.exists() is False
+    assert cached_submissions[1].exists() is False
+    assert cached_submissions[2].exists() is True
+    assert cached_submissions[2].read_text() == "22"
+    assert cached_submissions[3].exists() is False
+    assert cached_submissions[4].exists() is False


### PR DESCRIPTION
#### What
Create a local cache of job submissions for the jobbergate agent.:
* Check the local cache to see if a job submission was already dispatched to Slurm
* If the job was not already dispatched:
   * submit the job to Slurm
   * Create an entry in the cache to indicate that the job was submitted
* Attempt to update the Job Submission in the Jobbergate API
* If the update was successful delete the entry in the cache

#### Why
We've found a situation where the jobbergate-agent resubmits a job constantly to slurm despite the job having been successfully submitted.
After the Jobbergate Agent successfully submits a pending job submission to slurm, it then attempts to update the status of the job in the Jobbergate API to indicate that the job was submitted. However, if the call to update the job submission in the Jobbergate API fails for any reason, the job_submission will be left in the pending status. This means that in the next cycle of the Jobbergate Agent, it will still see the job as if it had never been submitted and will try to submit the job again.
`Task`: https://app.clickup.com/t/18022949/PENG-2342

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
