### PR TITLE
turn the agent snap to classic confinement

### DIFF
--- a/.github/workflows/publish_on_tag.yaml
+++ b/.github/workflows/publish_on_tag.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Output metadata
         working-directory: ${{ matrix.sub_project }}
-        if: ${{ matrix.sub_project }} == "jobbergate-agent"
+        if: matrix.sub_project == 'jobbergate-agent'
         id: extract-metadata
         run: |
           VERSION=$(find ./dist -name '*.tar.gz' | sed 's/.\/dist\/jobbergate_agent-\(.*\)\.tar\.gz/\1/')
@@ -173,11 +173,16 @@ jobs:
       - name: Install core24
         run: sudo snap install core24 --channel latest/stable
 
+      - name: Set up LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: 5.21/stable
+
       - name: Build snap
         id: build
         working-directory: ./jobbergate-agent-snap
         run: |
-          snapcraft --destructive-mode -v
+          make build ARGS="-v"
           SNAP_FILE_PATH=`find . -name '*.snap'`
           echo "snap_file_path=$SNAP_FILE_PATH" >> "$GITHUB_OUTPUT"
 

--- a/jobbergate-agent-snap/.gitignore
+++ b/jobbergate-agent-snap/.gitignore
@@ -7,3 +7,4 @@ parts/
 prime/
 stage/
 .tox
+commit-sha.txt

--- a/jobbergate-agent-snap/Makefile
+++ b/jobbergate-agent-snap/Makefile
@@ -15,6 +15,11 @@ qa: lint type ## Run all quality assurance checks
 format: ## Run the formatter
 	tox -e format
 
+.PHONY: build
+ build: ## Build the snap
+ 	@git rev-parse --short HEAD > sha/commit-sha.txt
+ 	@snapcraft $(ARGS)
+
 .PHONY: clean
 clean: ## Clean all files/folders created by the project
 	@find . -iname '*.pyc' -delete
@@ -24,6 +29,7 @@ clean: ## Clean all files/folders created by the project
 	@find . -iname '__pycache__' -delete
 	@find . -iname '.zip' -delete
 	@find . -type f -name "*.snap" -delete
+	@find . -iname 'commit-sha.txt' -delete
 	@rm -r .mypy_cache || true
 	@rm -r .ruff_cache || true
 	@rm -r .tox || true

--- a/jobbergate-agent-snap/snap/snapcraft.yaml
+++ b/jobbergate-agent-snap/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: jobbergate-agent
 base: core24
-version: '0.1.0'
+version: '0.2.0'
 summary: The Jobbergate Agent snap
 adopt-info: metadata
 license: MIT
@@ -44,6 +44,19 @@ parts:
     plugin: python
     python-packages:
     - jobbergate-agent
+    build-packages:
+    - python3
+    - libapt-pkg-dev
+    - gcc
+    - g++
+    - dpkg-dev
+    stage-packages:
+    - python3.12-minimal
+    - python3.12-venv
+    - libpython3.12-minimal
+    - libpython3.12-stdlib
+    build-attributes:
+    - enable-patchelf
 
   hooks:
     plugin: dump
@@ -55,7 +68,8 @@ parts:
     plugin: nil
     override-pull: |
       craftctl default
-      craftctl set version="$(craftctl get version)-$(git rev-parse --short HEAD)"
+      COMMIT_SHA=$(cat $SNAPCRAFT_PROJECT_DIR/sha/commit-sha.txt)
+      craftctl set version="$(craftctl get version)-$COMMIT_SHA"
 
   wrappers:
     plugin: dump
@@ -66,33 +80,21 @@ apps:
   daemon:
     command: bin/jg-run
     daemon: simple
-    plugs:
-    - network
     install-mode: disable
+    environment:
+      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:${PYTHONPATH}"
 
   start:
     command: commands/daemon.start
     daemon: simple
-    plugs:
-    - system-observe
     install-mode: disable
 
   stop:
     command: commands/daemon.stop
     daemon: simple
-    plugs:
-    - system-observe
     install-mode: disable
 
   restart:
     command: commands/daemon.restart
     daemon: simple
-    plugs:
-    - system-observe
     install-mode: disable
-
-hooks:
-  configure:
-    plugs:
-    - system-observe
-    - network


### PR DESCRIPTION
#### What
This PR modifies the Jobbergate Agent Snap to use the `classic` confinement instead of the `strict`.

#### Why
This is necessary because the agent requires access to the slurm binaries located at `/usr/bin`

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
