### PR TITLE
[ASP-5649] Enable positional arguments on "get-one" commands on Jobbergate-cli

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -4,6 +4,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
 
+- Enabled positional arguments to select entries using the cli [ASP-5649]
 
 ## 5.3.0 -- 2024-09-09
 

--- a/jobbergate-cli/jobbergate_cli/subapps/applications/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/applications/app.py
@@ -19,7 +19,7 @@ from jobbergate_cli.subapps.applications.tools import (
     upload_application,
 )
 from jobbergate_cli.subapps.pagination import handle_pagination
-from jobbergate_cli.subapps.tools import sanitize_application_selection
+from jobbergate_cli.subapps.tools import resolve_application_selection
 
 
 # TODO: move hidden field logic to the API
@@ -118,7 +118,7 @@ def get_one(
     ),
     identifier: Optional[str] = typer.Option(
         None,
-        help=f"Alternative way to specify identtifier. {IDENTIFIER_NOTE}",
+        help=f"Alternative way to specify identifier. {IDENTIFIER_NOTE}",
     ),
 ):
     """
@@ -126,7 +126,7 @@ def get_one(
     """
     jg_ctx: JobbergateContext = ctx.obj
     result = fetch_application_data(
-        jg_ctx, id_or_identifier=sanitize_application_selection(id_or_identifier, id, identifier)
+        jg_ctx, id_or_identifier=resolve_application_selection(id_or_identifier, id, identifier)
     )
     render_single_result(
         jg_ctx,
@@ -255,7 +255,7 @@ def update(
     """
     Update an existing application.
     """
-    identification = sanitize_application_selection(id_or_identifier, id, identifier)
+    identification = resolve_application_selection(id_or_identifier, id, identifier)
 
     req_data = dict()
 
@@ -335,7 +335,7 @@ def delete(
     # Make static type checkers happy
     assert jg_ctx.client is not None
 
-    identification = sanitize_application_selection(id_or_identifier, id, identifier)
+    identification = resolve_application_selection(id_or_identifier, id, identifier)
 
     # Delete the upload. The API will also remove the application data files
     make_request(
@@ -378,7 +378,7 @@ def download_files(
     """
     jg_ctx: JobbergateContext = ctx.obj
 
-    result = fetch_application_data(jg_ctx, sanitize_application_selection(id_or_identifier, id, identifier))
+    result = fetch_application_data(jg_ctx, resolve_application_selection(id_or_identifier, id, identifier))
     saved_files = save_application_files(
         jg_ctx,
         application_data=result,
@@ -431,7 +431,7 @@ def clone(
     """
     Clone an application, so the user can own and modify a copy of it.
     """
-    identification = sanitize_application_selection(id_or_identifier, id, identifier)
+    identification = resolve_application_selection(id_or_identifier, id, identifier)
 
     req_data = dict()
 

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -25,7 +25,7 @@ from jobbergate_cli.subapps.job_scripts.tools import (
 from jobbergate_cli.subapps.job_submissions.app import HIDDEN_FIELDS as JOB_SUBMISSION_HIDDEN_FIELDS
 from jobbergate_cli.subapps.job_submissions.tools import job_submissions_factory
 from jobbergate_cli.subapps.pagination import handle_pagination
-from jobbergate_cli.subapps.tools import sanitize_application_selection, sanitize_id_selection
+from jobbergate_cli.subapps.tools import resolve_application_selection, resolve_id_selection
 from jobbergate_cli.text_tools import dedent
 
 
@@ -102,7 +102,7 @@ def get_one(
     Get a single job script by id.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = sanitize_id_selection(id, id_option)
+    id = resolve_id_selection(id, id_option)
 
     result = fetch_job_script_data(jg_ctx, id)
     render_single_result(
@@ -312,7 +312,7 @@ def create(
     Create a new job script from an application.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    selector = sanitize_application_selection(id_or_identifier, application_id, application_identifier)
+    selector = resolve_application_selection(id_or_identifier, application_id, application_identifier)
 
     job_script_result = render_job_script(
         jg_ctx,
@@ -425,7 +425,7 @@ def update(
     Update an existing job script.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = sanitize_id_selection(id, id_option)
+    id = resolve_id_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx.client is not None
@@ -472,7 +472,7 @@ def delete(
     Delete an existing job script.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = sanitize_id_selection(id, id_option)
+    id = resolve_id_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx.client is not None
@@ -502,7 +502,7 @@ def show_files(
     Show the files for a single job script by id.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = sanitize_id_selection(id, id_option)
+    id = resolve_id_selection(id, id_option)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = pathlib.Path(tmp_dir)
@@ -535,7 +535,7 @@ def download_files(
     Download the files from a job script to the current working directory.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = sanitize_id_selection(id, id_option)
+    id = resolve_id_selection(id, id_option)
     downloaded_files = download_job_script_files(id, jg_ctx, pathlib.Path.cwd())
 
     terminal_message(
@@ -571,7 +571,7 @@ def clone(
     Clone an existing job script, so the user can own and modify a copy of it.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = sanitize_id_selection(id, id_option)
+    id = resolve_id_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx.client is not None

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/app.py
@@ -25,7 +25,7 @@ from jobbergate_cli.subapps.job_scripts.tools import (
 from jobbergate_cli.subapps.job_submissions.app import HIDDEN_FIELDS as JOB_SUBMISSION_HIDDEN_FIELDS
 from jobbergate_cli.subapps.job_submissions.tools import job_submissions_factory
 from jobbergate_cli.subapps.pagination import handle_pagination
-from jobbergate_cli.subapps.tools import resolve_application_selection, resolve_id_selection
+from jobbergate_cli.subapps.tools import resolve_application_selection, resolve_selection
 from jobbergate_cli.text_tools import dedent
 
 
@@ -102,7 +102,7 @@ def get_one(
     Get a single job script by id.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = resolve_id_selection(id, id_option)
+    id = resolve_selection(id, id_option)
 
     result = fetch_job_script_data(jg_ctx, id)
     render_single_result(
@@ -116,8 +116,8 @@ def get_one(
 @app.command()
 def create_stand_alone(
     ctx: typer.Context,
-    job_script_path: pathlib.Path = typer.Argument(
-        ..., help="The path to the job script file to upload", file_okay=True, readable=True
+    job_script_path: Optional[pathlib.Path] = typer.Argument(
+        None, help="The path to the job script file to upload", file_okay=True, readable=True
     ),
     name: str = typer.Option(
         ...,
@@ -126,6 +126,9 @@ def create_stand_alone(
     description: Optional[str] = typer.Option(
         None,
         help="Optional text describing the job script.",
+    ),
+    job_script_path_option: Optional[pathlib.Path] = typer.Option(
+        None, "--job-script-path", help="The path to the job script file to upload", file_okay=True, readable=True
     ),
     supporting_file_path: Optional[List[pathlib.Path]] = typer.Option(
         None,
@@ -140,6 +143,7 @@ def create_stand_alone(
     Create and upload files for a standalone job script (i.e., unrelated to any application).
     """
     jg_ctx: JobbergateContext = ctx.obj
+    job_script_path = resolve_selection(job_script_path, job_script_path_option, option_name="job_script_path")
 
     # Make static type checkers happy
     assert jg_ctx.client is not None
@@ -425,7 +429,7 @@ def update(
     Update an existing job script.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = resolve_id_selection(id, id_option)
+    id = resolve_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx.client is not None
@@ -472,7 +476,7 @@ def delete(
     Delete an existing job script.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = resolve_id_selection(id, id_option)
+    id = resolve_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx.client is not None
@@ -502,7 +506,7 @@ def show_files(
     Show the files for a single job script by id.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = resolve_id_selection(id, id_option)
+    id = resolve_selection(id, id_option)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = pathlib.Path(tmp_dir)
@@ -535,7 +539,7 @@ def download_files(
     Download the files from a job script to the current working directory.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = resolve_id_selection(id, id_option)
+    id = resolve_selection(id, id_option)
     downloaded_files = download_job_script_files(id, jg_ctx, pathlib.Path.cwd())
 
     terminal_message(
@@ -571,7 +575,7 @@ def clone(
     Clone an existing job script, so the user can own and modify a copy of it.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = resolve_id_selection(id, id_option)
+    id = resolve_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx.client is not None

--- a/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_scripts/tools.py
@@ -304,9 +304,8 @@ def render_job_script_locally(
 
 def render_job_script(
     jg_ctx: JobbergateContext,
+    id_or_identifier: int | str,
     name: Optional[str] = None,
-    application_id: Optional[int] = None,
-    application_identifier: Optional[str] = None,
     description: Optional[str] = None,
     sbatch_params: Optional[List[str]] = None,
     param_file: Optional[pathlib.Path] = None,
@@ -331,7 +330,7 @@ def render_job_script(
     # Make static type checkers happy
     assert jg_ctx.client is not None
 
-    app_data = fetch_application_data(jg_ctx, id=application_id, identifier=application_identifier)
+    app_data = fetch_application_data(jg_ctx, id_or_identifier)
 
     if not app_data.workflow_files:
         raise Abort(

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -15,7 +15,7 @@ from jobbergate_cli.requests import make_request
 from jobbergate_cli.schemas import JobbergateContext, JobSubmissionResponse
 from jobbergate_cli.subapps.job_submissions.tools import fetch_job_submission_data, job_submissions_factory
 from jobbergate_cli.subapps.pagination import handle_pagination
-from jobbergate_cli.subapps.tools import sanitize_id_selection
+from jobbergate_cli.subapps.tools import resolve_id_selection
 
 
 # move hidden field logic to the API
@@ -94,7 +94,7 @@ def create(
     Create a new job submission.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    job_script_id = sanitize_id_selection(job_script_id, job_script_id_option)
+    job_script_id = resolve_id_selection(job_script_id, job_script_id_option)
 
     try:
         submissions_handler = job_submissions_factory(
@@ -184,7 +184,7 @@ def get_one(
     Get a single job submission by id
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = sanitize_id_selection(id, id_option)
+    id = resolve_id_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx is not None, "JobbergateContext is uninitialized"
@@ -225,7 +225,7 @@ def delete(
     Delete an existing job submission.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = sanitize_id_selection(id, id_option)
+    id = resolve_id_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx.client is not None, "Client is uninitialized"

--- a/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/job_submissions/app.py
@@ -15,7 +15,7 @@ from jobbergate_cli.requests import make_request
 from jobbergate_cli.schemas import JobbergateContext, JobSubmissionResponse
 from jobbergate_cli.subapps.job_submissions.tools import fetch_job_submission_data, job_submissions_factory
 from jobbergate_cli.subapps.pagination import handle_pagination
-from jobbergate_cli.subapps.tools import resolve_id_selection
+from jobbergate_cli.subapps.tools import resolve_selection
 
 
 # move hidden field logic to the API
@@ -94,7 +94,7 @@ def create(
     Create a new job submission.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    job_script_id = resolve_id_selection(job_script_id, job_script_id_option)
+    job_script_id = resolve_selection(job_script_id, job_script_id_option)
 
     try:
         submissions_handler = job_submissions_factory(
@@ -184,7 +184,7 @@ def get_one(
     Get a single job submission by id
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = resolve_id_selection(id, id_option)
+    id = resolve_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx is not None, "JobbergateContext is uninitialized"
@@ -225,7 +225,7 @@ def delete(
     Delete an existing job submission.
     """
     jg_ctx: JobbergateContext = ctx.obj
-    id = resolve_id_selection(id, id_option)
+    id = resolve_selection(id, id_option)
 
     # Make static type checkers happy
     assert jg_ctx.client is not None, "Client is uninitialized"

--- a/jobbergate-cli/jobbergate_cli/subapps/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/tools.py
@@ -2,6 +2,8 @@
 Tools for the subapps.
 """
 
+from typing import TypeVar
+
 from click import UsageError
 
 
@@ -31,9 +33,12 @@ def resolve_application_selection(
     return valid_args[0]
 
 
-def resolve_id_selection(*args: int | None, option_name: str = "id") -> int:
+SelectionType = TypeVar("SelectionType")
+
+
+def resolve_selection(*args: SelectionType | None, option_name: str = "id") -> SelectionType:
     """
-    Resolve the id selection parameters.
+    Resolve the multiple optional selection parameters to ensure one value is indeed selected.
     """
     valid_args = [i for i in args if i is not None]
     counter = len(valid_args)

--- a/jobbergate-cli/jobbergate_cli/subapps/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/tools.py
@@ -1,0 +1,52 @@
+"""
+Tools for the subapps.
+"""
+
+from jobbergate_cli.exceptions import Abort
+
+
+def sanitize_application_selection(
+    id_or_identifier: int | str | None = None, id: int | None = None, identifier: str | None = None, prefix: str = ""
+) -> int | str:
+    """
+    Sanitize the application selection parameters.
+    """
+    counter = sum((0 if i is None else 1 for i in (id_or_identifier, id, identifier)))
+    prefix_underline = prefix.replace("-", "_") + "_"
+    prefix_dash = prefix.replace("_", "-") + "-"
+
+    if counter != 1:
+        raise Abort(
+            (
+                f"You must supply one and only one selection value "
+                f"(positional [yellow]{prefix_underline}id_or_identifier[/yellow], "
+                f"[yellow]--{prefix_dash}id[/yellow], or [yellow]{prefix_dash}identifier[/yellow]), got {counter}"
+            ),
+            subject="Invalid Selection",
+            support=False,
+        )
+    if isinstance(id_or_identifier, str) and id_or_identifier.isdigit():
+        id_or_identifier = int(id_or_identifier)
+
+    return id_or_identifier or id or identifier  # type: ignore
+
+
+def sanitize_id_selection(*args: int | None, option_name: str = "id") -> int:
+    """
+    Sanitize the id selection parameters.
+    """
+    valid_args = [i for i in args if i is not None]
+    counter = len(valid_args)
+
+    if counter != 1:
+        raise Abort(
+            (
+                "You must supply one and only one selection value "
+                f"(positional [yellow]{option_name}[/yellow] or "
+                f"[yellow]--{option_name.replace('_', '-')}[/yellow]), got {counter}",
+            ),
+            subject="Invalid Selection",
+            support=False,
+        )
+
+    return valid_args[0]

--- a/jobbergate-cli/jobbergate_cli/subapps/tools.py
+++ b/jobbergate-cli/jobbergate_cli/subapps/tools.py
@@ -2,51 +2,48 @@
 Tools for the subapps.
 """
 
-from jobbergate_cli.exceptions import Abort
+from click import UsageError
 
 
-def sanitize_application_selection(
+def resolve_application_selection(
     id_or_identifier: int | str | None = None, id: int | None = None, identifier: str | None = None, prefix: str = ""
 ) -> int | str:
     """
-    Sanitize the application selection parameters.
+    Resolve the application selection parameters.
     """
-    counter = sum((0 if i is None else 1 for i in (id_or_identifier, id, identifier)))
-    prefix_underline = prefix.replace("-", "_") + "_"
-    prefix_dash = prefix.replace("_", "-") + "-"
-
-    if counter != 1:
-        raise Abort(
-            (
-                f"You must supply one and only one selection value "
-                f"(positional [yellow]{prefix_underline}id_or_identifier[/yellow], "
-                f"[yellow]--{prefix_dash}id[/yellow], or [yellow]{prefix_dash}identifier[/yellow]), got {counter}"
-            ),
-            subject="Invalid Selection",
-            support=False,
-        )
     if isinstance(id_or_identifier, str) and id_or_identifier.isdigit():
         id_or_identifier = int(id_or_identifier)
 
-    return id_or_identifier or id or identifier  # type: ignore
+    valid_args = [i for i in (id_or_identifier, id, identifier) if i is not None]
+    counter = len(valid_args)
+
+    if counter != 1:
+        prefix_underline = prefix.replace("-", "_") + "_" if prefix else ""
+        prefix_dash = prefix_underline.replace("_", "-")
+        raise UsageError(
+            (
+                f"You must supply one and only one selection value "
+                f"(positional {prefix_underline}id_or_identifier, "
+                f"--{prefix_dash}id, or --{prefix_dash}identifier)"
+            )
+        )
+
+    return valid_args[0]
 
 
-def sanitize_id_selection(*args: int | None, option_name: str = "id") -> int:
+def resolve_id_selection(*args: int | None, option_name: str = "id") -> int:
     """
-    Sanitize the id selection parameters.
+    Resolve the id selection parameters.
     """
     valid_args = [i for i in args if i is not None]
     counter = len(valid_args)
 
     if counter != 1:
-        raise Abort(
+        raise UsageError(
             (
-                "You must supply one and only one selection value "
-                f"(positional [yellow]{option_name}[/yellow] or "
-                f"[yellow]--{option_name.replace('_', '-')}[/yellow]), got {counter}",
-            ),
-            subject="Invalid Selection",
-            support=False,
+                f"You must supply one and only one selection value "
+                f"(positional {option_name} or --{option_name.replace('_', '-')})"
+            )
         )
 
     return valid_args[0]

--- a/jobbergate-cli/tests/subapps/applications/test_tools.py
+++ b/jobbergate-cli/tests/subapps/applications/test_tools.py
@@ -60,7 +60,7 @@ def test_fetch_application_data__success__using_id(
         ),
     )
 
-    result = fetch_application_data(dummy_context, id=app_id)
+    result = fetch_application_data(dummy_context, id_or_identifier=app_id)
     assert fetch_route.called
     assert result == ApplicationResponse.model_validate(app_data)
 
@@ -81,19 +81,9 @@ def test_fetch_application_data__success__using_identifier(
         ),
     )
 
-    result = fetch_application_data(dummy_context, identifier=app_identifier)
+    result = fetch_application_data(dummy_context, id_or_identifier=app_identifier)
     assert fetch_route.called
     assert result == ApplicationResponse.model_validate(app_data)
-
-
-def test_fetch_application_data__fails_with_both_id_or_identifier(dummy_context):
-    with pytest.raises(Abort, match="You may not supply both"):
-        fetch_application_data(dummy_context, id=1, identifier="one")
-
-
-def test_fetch_application_data__fails_with_neither_id_or_identifier(dummy_context):
-    with pytest.raises(Abort, match="You must supply either"):
-        fetch_application_data(dummy_context)
 
 
 def test_load_application_data__success(dummy_module_source, dummy_config_source):
@@ -291,7 +281,7 @@ class TestUploadApplicationFiles:
         mocked_routes,
     ):
         with mocked_routes as routes:
-            upload_application(dummy_context, dummy_application_dir, self.application_id, None)
+            upload_application(dummy_context, dummy_application_dir, self.application_id)
 
             # Ensure just the filename is included, nothing extra from path
             filename_check = b'filename="jobbergate.py"\r\n'
@@ -306,28 +296,28 @@ class TestUploadApplicationFiles:
     def test_upload_application__fails_directory_does_not_exists(self, dummy_application_dir, dummy_context):
         application_path = dummy_application_dir / "does-not-exist"
         with pytest.raises(Abort, match="Application directory"):
-            upload_application(dummy_context, application_path, self.application_id, None)
+            upload_application(dummy_context, application_path, self.application_id)
 
     @respx.mock(assert_all_mocked=True)
     def test_upload_application__fails_config_file_not_found(self, dummy_application_dir, dummy_context):
         file_path = dummy_application_dir / JOBBERGATE_APPLICATION_CONFIG_FILE_NAME
         file_path.unlink()
         with pytest.raises(Abort, match="Application config file"):
-            upload_application(dummy_context, dummy_application_dir, self.application_id, None)
+            upload_application(dummy_context, dummy_application_dir, self.application_id)
 
     @respx.mock(assert_all_mocked=True)
     def test_upload_application__fails_module_file_not_found(self, dummy_application_dir, dummy_context):
         file_path = dummy_application_dir / JOBBERGATE_APPLICATION_MODULE_FILE_NAME
         file_path.unlink()
         with pytest.raises(Abort, match="Application module file"):
-            upload_application(dummy_context, dummy_application_dir, self.application_id, None)
+            upload_application(dummy_context, dummy_application_dir, self.application_id)
 
     @respx.mock(assert_all_mocked=True)
     def test_upload_application__fails_no_template_found(self, dummy_application_dir, dummy_context):
         file_path = dummy_application_dir / "templates" / "job-script-template.py.j2"
         file_path.unlink()
         with pytest.raises(Abort, match="No template files found in"):
-            upload_application(dummy_context, dummy_application_dir, self.application_id, None)
+            upload_application(dummy_context, dummy_application_dir, self.application_id)
 
 
 class TestDownloadApplicationFiles:

--- a/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
@@ -347,16 +347,12 @@ def test_render_job_script__providing_a_name(
 
     actual_job_script_data = render_job_script(
         dummy_context,
+        id_or_identifier=1,
         name=desired_job_script_data["name"],
-        application_id=1,
         fast=True,
     )
 
-    mocked_fetch_application_data.assert_called_once_with(
-        dummy_context,
-        id=1,
-        identifier=None,
-    )
+    mocked_fetch_application_data.assert_called_once_with(dummy_context, 1)
 
     assert actual_job_script_data == JobScriptResponse.model_validate(desired_job_script_data)
 
@@ -420,16 +416,12 @@ def test_render_job_script__set_name_dynamically_from_application_config(
 
     actual_job_script_data = render_job_script(
         dummy_context,
+        id_or_identifier=1,
         name=new_name,
-        application_id=1,
         fast=True,
     )
 
-    mocked_fetch_application_data.assert_called_once_with(
-        dummy_context,
-        id=1,
-        identifier=None,
-    )
+    mocked_fetch_application_data.assert_called_once_with(dummy_context, 1)
 
     assert actual_job_script_data == JobScriptResponse.model_validate(desired_job_script_data)
 
@@ -493,16 +485,12 @@ def test_render_job_script__set_name_dynamically_from_jobbergate_config(
 
     actual_job_script_data = render_job_script(
         dummy_context,
+        id_or_identifier=1,
         name=new_name,
-        application_id=1,
         fast=True,
     )
 
-    mocked_fetch_application_data.assert_called_once_with(
-        dummy_context,
-        id=1,
-        identifier=None,
-    )
+    mocked_fetch_application_data.assert_called_once_with(dummy_context, 1)
 
     assert actual_job_script_data == JobScriptResponse.model_validate(desired_job_script_data)
 
@@ -565,16 +553,12 @@ def test_render_job_script__without_a_name(
 
     actual_job_script_data = render_job_script(
         dummy_context,
+        id_or_identifier=application_response.application_id,
         name=None,
-        application_id=application_response.application_id,
         fast=True,
     )
 
-    mocked_fetch_application_data.assert_called_once_with(
-        dummy_context,
-        id=application_response.application_id,
-        identifier=None,
-    )
+    mocked_fetch_application_data.assert_called_once_with(dummy_context, application_response.application_id)
 
     assert actual_job_script_data == JobScriptResponse.model_validate(desired_job_script_data)
 

--- a/jobbergate-cli/tests/subapps/test_tools.py
+++ b/jobbergate-cli/tests/subapps/test_tools.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import pytest
+from click import UsageError
+from jobbergate_cli.subapps.tools import resolve_application_selection, resolve_selection
+
+
+class TestResolveApplicationSelection:
+    def test_resolve_application_selection_digit(self):
+        assert resolve_application_selection(id_or_identifier="123") == 123
+
+    def test_resolve_application_selection_string(self):
+        assert resolve_application_selection(id_or_identifier="app-identifier") == "app-identifier"
+
+    def test_resolve_application_selection_identifier_only(self):
+        assert resolve_application_selection(identifier="app-identifier") == "app-identifier"
+
+    def test_resolve_application_selection_id_only(self):
+        assert resolve_application_selection(id=456) == 456
+
+    def test_resolve_application_selection_all_null(self):
+        with pytest.raises(UsageError, match="^You must supply one and only one selection value"):
+            resolve_application_selection(id_or_identifier=None, id=None, identifier=None)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"id_or_identifier": "123", "id": 456},
+            {"id_or_identifier": "123", "identifier": "app-identifier"},
+            {"id": 456, "identifier": "app-identifier"},
+        ],
+    )
+    def test_resolve_application_selection_multiple_args(self, kwargs):
+        with pytest.raises(UsageError, match="^You must supply one and only one selection value"):
+            resolve_application_selection(**kwargs)
+
+
+class TestResolveSelection:
+    @pytest.mark.parametrize("value", [10, "value", Path("test-test")])
+    def test_resolve_selection_single_value(self, value):
+        assert resolve_selection(None, value, None) == value
+
+    def test_resolve_selection_no_arguments(self):
+        with pytest.raises(UsageError, match="^You must supply one and only one selection value"):
+            resolve_selection(option_name="test")
+
+    def test_resolve_selection_all_null(self):
+        with pytest.raises(UsageError, match="^You must supply one and only one selection value") as exec_info:
+            resolve_selection(None, None, None, option_name="test_option")
+
+        expected_message = "You must supply one and only one selection value (positional test_option or --test-option)"
+        assert exec_info.value.message == expected_message
+
+    @pytest.mark.parametrize("value", [10, "value", Path("test-test")])
+    def test_resolve_selection_multiple_values(self, value):
+        with pytest.raises(UsageError, match="^You must supply one and only one selection value"):
+            resolve_selection(value, value)


### PR DESCRIPTION
#### What

All the Jobbergate commands that select one entry do it by command line options like `--id`, or `--identifier`, for instance:

```
jobbergate applications get-one --id <application_id> ...
jobbergate applications get-one --identifier <application_identifier> ...
```

Since the identification is required when selecting a given entry, it can be changed to a positional argument. In this way, it can be provided right after the command with no need to type `--id` or `--identifier` every time. For instance: 

```
jobbergate applications get-one <application_id> ...
jobbergate applications get-one <application_identifier> ...
```

This was just an example on `jobbergate applications get-one`, but this enhancement can also be extended to many other commands.

#### Why
As a Jobbergate user, I want a simplified way to select entries on the jobbergate commands, so that my experience using the cli is less typing intensive.

`Task`: https://jira.scania.com/browse/ASP-5649

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
