### PR TITLE
fix(agent): avoid propagating env variables to slurm jobs

### DIFF
--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -4,6 +4,7 @@ This file keeps track of all notable changes to jobbergate-agent
 
 ## Unreleased
 
+- Fixed environment variables from the machine running the agent propagating to slurm jobs (notice `--export=ALL` is the default behavior for sbatch)
 
 ## 5.3.0 -- 2024-09-09
 

--- a/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/submit.py
@@ -174,7 +174,7 @@ class SubprocessAsUserHandler(SubprocessHandler):
         self.gid = pwan.pw_gid
 
     def run(self, *args, **kwargs):
-        kwargs.update(user=self.uid, group=self.gid)
+        kwargs.update(user=self.uid, group=self.gid, env={})
         # Tests indicate that the change on the working directory precedes the change of user on the subprocess.
         # With that, the user running the agent can face permission denied errors on cwd,
         # depending on the setting on the filesystem and permissions on the directory.

--- a/jobbergate-agent/jobbergate_agent/utils/sentry.py
+++ b/jobbergate-agent/jobbergate_agent/utils/sentry.py
@@ -17,6 +17,7 @@ def init_sentry():
             integrations=[sentry_logging],
             traces_sample_rate=1.0,
             environment=SETTINGS.SENTRY_ENV,
+            propagate_traces=False,  # Do not propagate traces to child processes (e.g. sbatch subprocesses)
         )
 
         logger.debug("##### Enabled Sentry since a valid DSN key was provided.")


### PR DESCRIPTION
#### What
Avoid propagating environment variables to slurm jobs

#### Why

The [default mode on sbatch](https://slurm.schedmd.com/sbatch.html#OPT_export_1) is:

> --export=ALL: Default mode if --export is not specified. All of the user's environment will be loaded (either from the caller's environment or from a clean environment if --get-user-env is specified).

With that, a couple variables from the machine running the agent could overwrite the ones on the slurm job.


---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
