### PR TITLE
Tucker/peng 2426  add upload by url endpoints to jobbergate api

### DIFF
--- a/jobbergate-api/Makefile
+++ b/jobbergate-api/Makefile
@@ -3,49 +3,39 @@
 SHELL:=/bin/bash
 PACKAGE_NAME:=jobbergate_api
 
-.PHONY: install
-install:
+install:  ## Install the package locally for development.
 	poetry install
 
-.PHONY: test
-test: install
+test: install  ## Run the unit tests.
 	poetry run pytest
 
-.PHONY: mypy
-mypy: install
+mypy: install  ## Run static type checking on the code base.
 	poetry run mypy ${PACKAGE_NAME} --pretty
 
-.PHONY: lint
-lint: install
+lint: install  ## Run linters over the code base.
 	poetry run ruff check tests ${PACKAGE_NAME}
 
-.PHONY: format
-format: install
+format: install  ## Autoformat the code base.
 	poetry run ruff format tests ${PACKAGE_NAME}
 
-.PHONY: qa
-qa: test mypy lint format
+qa: test mypy lint format  ## Run all quality checks.
 	echo "All quality checks pass!"
 
-.PHONY: local
-local: install
+local: install  ## Run a local dev server.
 	poetry run dev-tools dev-server --port=8000
 
 # To include a message with the generated migration, set the MESSAGE variable in the make command:
 #   $ make db-migration MESSAGE="this migration applies foo to bar"
-.PHONY: db-migrate
-db-migrate: install
+db-migrate: install  ## Create a migration for the database based on the current models.
 	poetry run alembic --config=alembic/alembic.ini revision --autogenerate --message "$(MESSAGE)"
 
 # To override the upgrade target from head, set the UPGRADE_TARGET variable in the make command:
 #   $ make db-upgrade UPGRADE_TARGET=bf1e9e
 UPGRADE_TARGET ?= head
-.PHONY: db-upgrade
-db-upgrade: install
+db-upgrade: install  ## Upgrade the database to a specified target. Defaults to latest.
 	poetry run alembic --config=alembic/alembic.ini upgrade $(UPGRADE_TARGET)
 
-.PHONY: clean
-clean:
+clean:  ## Clean up build artifacts and other junk
 	@find . -iname '*.pyc' -delete
 	@find . -iname '*.pyo' -delete
 	@find . -iname '*~' -delete
@@ -57,6 +47,6 @@ clean:
 	@rm -fr dist/
 	@rm -fr *.egg-info
 
-.PHONY: help
-help: # Display target comments in 'make help'
-	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+# Recipe stolen from: https://gist.github.com/prwhite/8168133?permalink_comment_id=4160123#gistcomment-4160123
+help:  ## Show help message
+	@awk 'BEGIN {FS = ": .*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[$$()% 0-9a-zA-Z_-]+(\\:[$$()% 0-9a-zA-Z_-]+)*:.*?##/ { gsub(/\\:/,":", $$1); printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/jobbergate-api/jobbergate_api/main.py
+++ b/jobbergate-api/jobbergate_api/main.py
@@ -19,7 +19,7 @@ from jobbergate_api.apps.job_script_templates.routers import router as job_scrip
 from jobbergate_api.apps.job_scripts.routers import router as job_scripts_router
 from jobbergate_api.apps.job_submissions.routers import router as job_submissions_router
 from jobbergate_api.config import settings
-from jobbergate_api.logging import init_logging, RouteFilterParams
+from jobbergate_api.logging import init_logging
 from jobbergate_api.storage import engine_factory, handle_fk_error
 
 subapp = FastAPI(
@@ -88,8 +88,7 @@ async def lifespan(_: FastAPI):
     This is the preferred method of handling lifespan events in FastAPI.
     For mor details, see: https://fastapi.tiangolo.com/advanced/events/
     """
-    # Supress logging on the health check endpoint
-    init_logging(supress_routes=[RouteFilterParams(verb="GET", route="/jobbergate/health")])
+    init_logging()
 
     yield
 

--- a/jobbergate-composed/docker-compose.yml
+++ b/jobbergate-composed/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       - AWS_ACCESS_KEY_ID=compose-s3-key
       - AWS_SECRET_ACCESS_KEY=compose-s3-secret
       - ARMASEC_DOMAIN=keycloak.local:8080/realms/jobbergate-local
-      - ARMASEC_AUDIENCE=https://local.omnivector.solutions
       - ARMASEC_DEBUG=false
       - ARMASEC_USE_HTTPS=false
       - LOG_LEVEL=DEBUG


### PR DESCRIPTION
#### What
    PENG-2426 Fixed file uploads with s3

    Jobbergate uses MinIO for file storage internally. The s3 clients use
    environment variables for the AWS secrets. These secrets are bound to
    the MinIO instance. They will not work for s3 in general. When we were
    trying to pull files by URL from s3, our clients were trying to use the
    credentials stored in the environment. These credentials were not known
    by s3.

    Instead of doing all that, we make the assumption that download-by-url
    will require the files to be available publicly. Consequently, we can
    construct a normal https URL to download the file.

    This change applies that logic and fixes the unit tests.

`Task`: https://app.clickup.com/t/18022949/PENG-2426

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
