### PR TITLE
PENG-2426 Fixed error code when user supplies bad url

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/services.py
+++ b/jobbergate-api/jobbergate_api/apps/services.py
@@ -584,7 +584,7 @@ class FileService(DatabaseBoundService, BucketBoundService, Generic[FileModel]):
         with handle_errors(
             f"Failed to download file from {file_url}",
             raise_exc_class=ServiceError,
-            raise_kwargs=dict(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR),
+            raise_kwargs=dict(status_code=status.HTTP_400_BAD_REQUEST),
         ):
             response = httpx.get(file_url_string)
             response.raise_for_status()

--- a/jobbergate-api/tests/apps/test_services.py
+++ b/jobbergate-api/tests/apps/test_services.py
@@ -810,23 +810,23 @@ class TestFileService:
         file_obj = await dummy_file_service._get_file_data_from_url(AnyUrl(s3_url))
         assert file_obj.read() == file_content
 
-    async def test__get_file_data_from_url__raises_500_if_download_fails(
+    async def test__get_file_data_from_url__raises_400_if_download_fails(
         self, dummy_file_service, respx_mock
     ):
         """
-        Test that the ``_get_file_data_from_url()`` method raises a 500 error if the download fails.
+        Test that the ``_get_file_data_from_url()`` method raises a 400 error if the download fails.
         """
         file_url = "https://dummy-domain.com/dummy-file.txt"
 
         respx_mock.get(file_url).mock(return_value=httpx.Response(httpx.codes.IM_A_TEAPOT))
         with pytest.raises(ServiceError, match="Failed to download") as exc_info:
             await dummy_file_service._get_file_data_from_url(AnyUrl(file_url))
-        assert exc_info.value.status_code == 500
+        assert exc_info.value.status_code == 400
 
         respx_mock.get(file_url).mock(side_effect=RuntimeError)
         with pytest.raises(ServiceError, match="Failed to download") as exc_info:
             await dummy_file_service._get_file_data_from_url(AnyUrl(file_url))
-        assert exc_info.value.status_code == 500
+        assert exc_info.value.status_code == 400
 
     @pytest.mark.parametrize(
         "file_url,error_stub",


### PR DESCRIPTION
#### What
Modified the error code for a bad URL to be a 400.

#### Why
It's not a server error if we can't download from a bad URL. It's an error with the request, hence it should be a 400.

`Task`: https://app.clickup.com/t/18022949/PENG-2426

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
