### PR TITLE
[ASP-4598] Modernize Dockerfile for jobbergate-api

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
+- Modernized Dockerile to use multi-stage builds [ASP-4598]
 
 
 ## 5.4.0a0 -- 2024-11-04

--- a/jobbergate-api/Dockerfile
+++ b/jobbergate-api/Dockerfile
@@ -1,16 +1,27 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-buster AS builder
+
+WORKDIR /app
 
 RUN apt update && apt install -y curl libpq-dev gcc
 
-RUN curl -sSL https://install.python-poetry.org | \
-    POETRY_HOME=/opt/poetry POETRY_VERSION=1.5.1 python && \
-    cd /usr/local/bin && \
-    ln -s /opt/poetry/bin/poetry && \
-    poetry config virtualenvs.create false
+RUN pip install poetry==1.5.1
 
-COPY ./pyproject.toml ./poetry.lock* /app/
+COPY ./pyproject.toml ./poetry.lock /app
+
+RUN poetry config virtualenvs.in-project true \
+    && poetry install --no-root \
+    && rm -rf "$POETRY_CACHE_DIR"
+
+
+FROM python:3.11-slim-buster AS runner
+
 WORKDIR /app
-RUN poetry install --no-root
+
+RUN apt update && apt install -y curl
+
+COPY --from=builder /app /app
+
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY ./alembic /app/alembic
 COPY ./jobbergate_api /app/jobbergate_api


### PR DESCRIPTION
#### What
Modernize the Dockerfile for `jobbergate-api` to use multi-stage builds.

#### Why
To reduce the size of the final image from ~600MB to ~300MB.

```
REPOSITORY                           TAG                            IMAGE ID       CREATED          SIZE
jobbergate-api-old                   latest                         49b18b3c4131   6 seconds ago    692MB
jobbergate-api-new                   latest                         b1530f954358   3 minutes ago    384MB
```

`Task`: https://jira.scania.com/browse/ASP-4598

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
