### PR TITLE
Add re-submit command to CLI's job-submissions sub-command

### DIFF
--- a/jobbergate-cli/CHANGELOG.md
+++ b/jobbergate-cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to jobbergate-cli
 
 ## Unreleased
-
+- Added clone command to job submissions so they can be resubmitted to the cluster when needed [PENG-1677, ASP-4597]
 
 ## 5.4.0a2 -- 2024-11-06
 ## 5.4.0a1 -- 2024-11-05

--- a/jobbergate-cli/jobbergate_cli/schemas.py
+++ b/jobbergate-cli/jobbergate_cli/schemas.py
@@ -245,6 +245,7 @@ class JobSubmissionResponse(pydantic.BaseModel, extra="ignore"):
     updated_at: Optional[datetime] = None
     report_message: Optional[str] = None
     sbatch_arguments: Optional[list[str]] = None
+    cloned_from_id: Optional[int] = None
 
 
 class JobScriptCreateRequest(pydantic.BaseModel):


### PR DESCRIPTION
#### What
- Add a sub-command to job-submissions to resubmit given a prior job-submission id
- Re-use the parameters and job-scripts from the previous submission
- Add unit tests and documentation as needed

#### Why
The jobbergate-cli needs to interact with the new `clone` endpoint for job-submissions.

`Tasks`:
* https://app.clickup.com/t/18022949/PENG-1677
* https://jira.scania.com/browse/ASP-4597

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
