### PR TITLE
patch the snapcraft.yaml file to set the confinement as classic

### DIFF
--- a/jobbergate-agent-snap/snap/snapcraft.yaml
+++ b/jobbergate-agent-snap/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: jobbergate-agent
 base: core24
-version: '0.2.0'
+version: '0.3.0'
 summary: The Jobbergate Agent snap
 adopt-info: metadata
 license: MIT
@@ -36,7 +36,7 @@ description: |
   For learning more about Jobbergate and how it can be used on Vantage, please visit https://docs.vantagehpc.io
 
 grade: stable
-confinement: strict
+confinement: classic
 
 parts:
   jobbergate-agent:


### PR DESCRIPTION
#### What
This PR fixes the code introduced by #634 by patching the `confinement` in the `snapcraft.yaml` file.

#### Why
Necessary to properly install the snap as classic.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
