### PR TITLE
fix(api): run rendering process in a Sandbox Environment

### DIFF
--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
+- Fixed issue on the Job Template rendering process by running it inside a Jinja Sandbox Environment
 
 ## 5.4.0 -- 2024-11-18
 

--- a/jobbergate-api/tests/apps/test_services.py
+++ b/jobbergate-api/tests/apps/test_services.py
@@ -903,6 +903,23 @@ class TestFileService:
         assert "TemplateSyntaxError" in exc_info.value.detail
         assert "Unable to process jinja template filename=file-one.txt" in exc_info.value.detail
 
+    async def test_render__raises_422_on_sandbox_violation(self, make_upload_file, dummy_file_service):
+        """
+        Test that the ``render()`` method raises a 422 error if the template unsecure.
+        """
+        dummy_upload_file = make_upload_file()
+        with make_upload_file(content="dummy {{ foo.__str__() }} content") as dummy_upload_file:
+            upserted_instance = await dummy_file_service.upsert(
+                13,
+                "file-one.txt",
+                dummy_upload_file,
+            )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await dummy_file_service.render(upserted_instance, parameters=dict(foo="bar"))
+        assert exc_info.value.status_code == 422
+        assert "Jinja can not render filename=file-one.txt" in exc_info.value.detail
+
     async def test_render__backward_compatible(self, make_upload_file, dummy_file_service):
         """
         Test that the ``render()`` works in different contexts.

--- a/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
@@ -182,6 +182,14 @@ def test_render_template__fail_when_unable_to_render(tmp_path):
     with pytest.raises(Abort, match="Unable to render"):
         render_template(template_path, parameters)
 
+def test_render_template__fail_sandbox_violation(tmp_path):
+    template_path = tmp_path / "dummy.j2"
+    template_path.write_text("{{ foo.__str__() }}")
+
+    parameters = dict(foo="bla")
+
+    with pytest.raises(Abort, match="Security errors raised when rendering"):
+        render_template(template_path, parameters)
 
 def test_render_template__fails_if_template_does_not_exist(tmp_path):
     non_exist = tmp_path / "does/not/exist"


### PR DESCRIPTION
#### What
Change the Job Template process to run inside a Jinja Sandbox Enrivonment.

#### Why
Secure the process.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
