### PR TITLE
Disable agent auto update in snaps

### DIFF
--- a/jobbergate-agent-snap/hooks/bin/configure
+++ b/jobbergate-agent-snap/hooks/bin/configure
@@ -17,7 +17,6 @@ AGENT_VARIABLES_MAP: dict[str, Union[str, int]] = {
     "OIDC_CLIENT_ID": "",
     "OIDC_CLIENT_SECRET": "",
     "TASK_JOBS_INTERVAL_SECONDS": 30,
-    "TASK_SELF_UPDATE_INTERVAL_SECONDS": 30,
     "CACHE_DIR": f"{SNAP_COMMON_PATH}/.cache",
     "SBATCH_PATH": "/usr/bin/sbatch",
     "SCONTROL_PATH": "/usr/bin/scontrol",

--- a/jobbergate-agent-snap/snap/snapcraft.yaml
+++ b/jobbergate-agent-snap/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: jobbergate-agent
 base: core22
-version: '0.4.0'
+version: '0.5.0'
 summary: The Jobbergate Agent snap
 adopt-info: metadata
 license: MIT
@@ -18,8 +18,6 @@ description: |
   - oidc-client-secret: The client secret of the OIDC application that the agent will use for authentication.
 
   - task-jobs-interval-seconds: The interval in seconds at which the agent will run its internal task jobs, hence sending data to the Jobbergate API server. This is optional and defaults to 30 seconds.
-
-  - task-self-update-interval-seconds: The interval in seconds at which the agent will check for updates to itself. This is optional and defaults to 30 seconds (1 hour).
 
   - sbatch-path: The absolute path to the *sbatch* command on the host system. This is optional and defaults to /usr/bin/sbatch.
 


### PR DESCRIPTION
#### What
This PR removes the configuration *task-self-update-interval-seconds* from the jobbergate agent snap.

#### Why
The agent is not supposed to update itself when deployed by the snap.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
