### PR TITLE
ci: change references from personal access token to github one

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -11,6 +11,10 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     name: Backport
@@ -30,6 +34,6 @@ jobs:
       - name: Generate backport
         uses: tibdex/backport@v2
         with:
-          github_token: ${{ secrets.TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           title_template: "[<%= base %>] <%= title %>"
           label_pattern: "^backport/(?<base>([^ ]+))$"

--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -24,6 +24,10 @@ on:
           - premajor
           - prerelease
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest
@@ -86,7 +90,7 @@ jobs:
         name: Create Pull Request
         id: cpr
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Prepared release ${{ steps.api-package.outputs.version }}"
           branch: "prepare-release/${{ steps.api-package.outputs.version }}"
           title: "Release ${{ steps.api-package.outputs.version }}"

--- a/.github/workflows/tag_on_merged_pull_request.yaml
+++ b/.github/workflows/tag_on_merged_pull_request.yaml
@@ -13,6 +13,9 @@ on:
       - release/**
     types: [closed]
 
+permissions:
+  contents: write
+
 jobs:
   create-tag:
     if: (github.event.pull_request.merged && startsWith(github.head_ref, 'prepare-release/'))
@@ -20,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: bluwy/substitute-string-action@v1
         name: Get Tag


### PR DESCRIPTION
In this way `github-actions` bot signs Pull Requests and make it clear they came from automated actions.
