### PR TITLE
fix(agent): PENG-2457 fix the *epoch* param when querying InfluxDB for metrics.

### DIFF
--- a/jobbergate-agent/jobbergate_agent/jobbergate/update.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/update.py
@@ -114,7 +114,7 @@ async def fetch_influx_data(
         assert influxdb_client is not None  # mypy assertion
 
         logger.debug(f"Querying InfluxDB with: {query=}, {params=}")
-        result = influxdb_client.query(query, bind_params=params, epoch="us")
+        result = influxdb_client.query(query, bind_params=params, epoch="s")
         logger.debug("Successfully fetched data from InfluxDB")
 
         return [

--- a/jobbergate-agent/tests/jobbergate/test_update.py
+++ b/jobbergate-agent/tests/jobbergate/test_update.py
@@ -382,7 +382,7 @@ async def test_fetch_influx_data__success_with_all_set(mocked_influxdb_client: m
     assert result[0]["task"] == task
     assert result[0]["value"] == measurement_value
     assert result[0]["measurement"] == measurement
-    mocked_influxdb_client.query.assert_called_once_with(query, bind_params=params, epoch="us")
+    mocked_influxdb_client.query.assert_called_once_with(query, bind_params=params, epoch="s")
 
 
 @pytest.mark.asyncio
@@ -425,7 +425,7 @@ async def test_fetch_influx_data__success_with_all_None(mocked_influxdb_client: 
     assert result[0]["task"] == task
     assert result[0]["value"] == measurement_value
     assert result[0]["measurement"] == measurement
-    mocked_influxdb_client.query.assert_called_once_with(query, bind_params=params, epoch="us")
+    mocked_influxdb_client.query.assert_called_once_with(query, bind_params=params, epoch="s")
 
 
 @pytest.mark.asyncio
@@ -495,7 +495,7 @@ async def test_fetch_influx_data__raises_JobbergateAgentError_if_query_fails(moc
             task=task,
         )
 
-    mocked_influxdb_client.query.assert_called_once_with(query, bind_params=params, epoch="us")
+    mocked_influxdb_client.query.assert_called_once_with(query, bind_params=params, epoch="s")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR modifies the *epoch* param of the `.query` method in the function *fetch_influx_data* when querying InfluxDB for metrics. The previous argument, i.e. *us*, was generating errors in the API when converting the timestamp to `datetime` objects necessary for SQLAlchemy.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
