### PR TITLE
fix(agent): PENG-2457 modify the time param used for querying InfluxDB

### DIFF
--- a/jobbergate-agent/jobbergate_agent/jobbergate/update.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/update.py
@@ -173,7 +173,7 @@ async def update_job_metrics(active_job_submittion: ActiveJobSubmission) -> None
                 fetch_influx_data(
                     active_job_submittion.slurm_job_id,
                     measurement["name"],
-                    time=job_max_time.max_time,
+                    time=int(job_max_time.max_time * 1e9),  # convert to ns since the agent sends in seconds
                     host=job_max_time.node_host,
                     step=job_max_time.step,
                     task=job_max_time.task,

--- a/jobbergate-agent/tests/jobbergate/test_update.py
+++ b/jobbergate-agent/tests/jobbergate/test_update.py
@@ -676,7 +676,7 @@ async def test_update_job_metrics__error_sending_metrics_to_api(
             mock.call(
                 slurm_job_id,
                 measurement["name"],
-                time=job_max_time["max_time"],
+                time=int(job_max_time["max_time"] * 1e9),
                 host=job_max_time["node_host"],
                 step=job_max_time["step"],
                 task=job_max_time["task"],
@@ -768,7 +768,7 @@ async def test_update_job_metrics__success(
             mock.call(
                 slurm_job_id,
                 measurement["name"],
-                time=job_max_time["max_time"],
+                time=int(job_max_time["max_time"] * 1e9),
                 host=job_max_time["node_host"],
                 step=job_max_time["step"],
                 task=job_max_time["task"],


### PR DESCRIPTION
This PR modifies the query made against InfluxDB when fetching for job metrics in a way that the *time* argument is given in nanoseconds. This is necessary because the agent sends the time in seconds, so, when fetching the *max_times*, the API will send the time in seconds as well.

However, the data stored in InfluxDB uses the epoch in nanoseconds, which requires the conversion before executing the query, otherwise all data in the database will be returned.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
