### PR TITLE
fix(agent): PENG-2457 defer sending data to the API in case there's no new data

### DIFF
--- a/jobbergate-agent/jobbergate_agent/jobbergate/update.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/update.py
@@ -184,6 +184,9 @@ async def update_job_metrics(active_job_submittion: ActiveJobSubmission) -> None
         results = await asyncio.gather(*list(tasks))
         data_points = chain.from_iterable(results)
         aggregated_data_points = aggregate_influx_measures(data_points)
+        if not aggregated_data_points:
+            # defer the API call since there's no data to be sent
+            return
         packed_data = msgpack.packb(aggregated_data_points)
 
         response = await jobbergate_api_client.put(


### PR DESCRIPTION
This PR introduces a change in the *update_job_metrics* function so the API call to insert new metrics is deferred in case there's no new metric, i.e. the list of metrics is empty.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
