### PR TITLE
feat(api): PENG-2455 create endpoint for fetching timestamps associated to metrics

### DIFF
--- a/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
@@ -5,7 +5,18 @@ Database model for the JobSubmission resource.
 from __future__ import annotations
 from datetime import datetime, timezone
 
-from sqlalchemy import ARRAY, Dialect, Enum, ForeignKey, Integer, String, Float, Index, PrimaryKeyConstraint, BigInteger
+from sqlalchemy import (
+    ARRAY,
+    Dialect,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    Float,
+    Index,
+    PrimaryKeyConstraint,
+    BigInteger,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship, selectinload
 from sqlalchemy.sql.expression import Select
 from sqlalchemy.types import DateTime, TypeDecorator

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/schemas.py
@@ -316,3 +316,12 @@ class JobSubmissionMetricSchema(BaseModel):
             raise ValueError("The iterable must have the same length as the model fields.")
 
         return cls(**{field: value for field, value in zip(fields, iterable)})
+
+
+class JobSubmissionMetricTimestamps(BaseModel):
+    """Model for the timestamps of the JobSubmissionMetric resource."""
+
+    min: int
+    max: int
+
+    model_config = ConfigDict(from_attributes=True, extra="ignore")

--- a/jobbergate-api/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/tests/apps/job_submissions/test_routers.py
@@ -2628,7 +2628,7 @@ async def test_job_submissions_metrics__start_time_less_greater_than_end_time(
         (Permissions.JOB_SUBMISSIONS_READ, 8),
     ],
 )
-async def job_submissions_metrics_timestamps__successful_request(
+async def test_job_submissions_metrics_timestamps__successful_request(
     permission,
     num_rows,
     fill_job_script_data,
@@ -2685,7 +2685,7 @@ async def job_submissions_metrics_timestamps__successful_request(
     query = insert(JobSubmissionMetric).values(formatted_data)
     await synth_session.execute(query)
 
-    inject_security_header("who@cares.com", permission, client_id="dummy-client")
+    inject_security_header("who@cares.com", permission)
     response = await client.get(
         f"/jobbergate/job-submissions/{inserted_job_submission_id}/metrics/timestamps"
     )
@@ -2705,18 +2705,19 @@ async def job_submissions_metrics_timestamps__successful_request(
         (Permissions.JOB_SUBMISSIONS_READ, 4967),
     ],
 )
-async def job_submissions_metrics_timestamps__job_submission_not_found(
+async def test_job_submissions_metrics_timestamps__job_submission_not_found(
     permission,
     job_submission_id,
     client,
     inject_security_header,
+    synth_services,
 ):
     """
     Test GET /job-submissions/{job_submission_id}/metrics/timestamps returns 404
     when the job submission doesn't exist
     """
 
-    inject_security_header("who@cares.com", permission, client_id="dummy-client")
+    inject_security_header("who@cares.com", permission)
     response = await client.get(f"/jobbergate/job-submissions/{job_submission_id}/metrics/timestamps")
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -2729,12 +2730,9 @@ async def job_submissions_metrics_timestamps__job_submission_not_found(
 
 @pytest.mark.parametrize(
     "permission",
-    [
-        (Permissions.ADMIN,),
-        (Permissions.JOB_SUBMISSIONS_READ,),
-    ],
+    [Permissions.ADMIN, Permissions.JOB_SUBMISSIONS_READ],
 )
-async def job_submissions_metrics_timestamps__job_submission_has_no_metric(
+async def test_job_submissions_metrics_timestamps__job_submission_has_no_metric(
     permission,
     fill_job_script_data,
     fill_job_submission_data,
@@ -2770,6 +2768,6 @@ async def job_submissions_metrics_timestamps__job_submission_has_no_metric(
 
     response_data = response.json()
     assert (
-        response_data
+        response_data["detail"]
         == f"No metrics found for job submission {inserted_job_submission_id} or job submission does not exist"
     )

--- a/jobbergate-api/tests/apps/job_submissions/test_routers.py
+++ b/jobbergate-api/tests/apps/job_submissions/test_routers.py
@@ -2619,3 +2619,157 @@ async def test_job_submissions_metrics__start_time_less_greater_than_end_time(
     mocked_session_execute.return_value.fetchall.assert_not_called()
     mocked_sa_text.assert_not_called()
     assert response.json() == {"detail": "End time must be greater than the start time."}
+
+
+@pytest.mark.parametrize(
+    "permission, num_rows",
+    [
+        (Permissions.ADMIN, 3),
+        (Permissions.JOB_SUBMISSIONS_READ, 8),
+    ],
+)
+async def job_submissions_metrics_timestamps__successful_request(
+    permission,
+    num_rows,
+    fill_job_script_data,
+    fill_job_submission_data,
+    client,
+    inject_security_header,
+    synth_services,
+    synth_session,
+):
+    """
+    Test GET /job-submissions/{job_submission_id}/metrics/timestamps returns 200 upon a successful request.
+    """
+    base_job_script = await synth_services.crud.job_script.create(**fill_job_script_data())
+
+    inserted_job_script_id = base_job_script.id
+
+    inserted_submission = await synth_services.crud.job_submission.create(
+        job_script_id=inserted_job_script_id,
+        **fill_job_submission_data(
+            client_id="dummy-client",
+            status=JobSubmissionStatus.SUBMITTED,
+            slurm_job_id=111,
+            slurm_job_state=SlurmJobState.PENDING,
+            slurm_job_info="Fake slurm job info",
+        ),
+    )
+    inserted_job_submission_id = inserted_submission.id
+
+    base_time = int(datetime.now().timestamp())
+    raw_data = generate_job_submission_metric_columns(base_time, num_rows)
+
+    formatted_data = [
+        {
+            "time": data_point[0],
+            "node_host": data_point[1],
+            "step": data_point[2],
+            "task": data_point[3],
+            "cpu_frequency": data_point[4],
+            "cpu_time": data_point[5],
+            "cpu_utilization": data_point[6],
+            "gpu_memory": data_point[7],
+            "gpu_utilization": data_point[8],
+            "page_faults": data_point[9],
+            "memory_rss": data_point[10],
+            "memory_virtual": data_point[11],
+            "disk_read": data_point[12],
+            "disk_write": data_point[13],
+            "job_submission_id": inserted_job_submission_id,
+            "slurm_job_id": inserted_submission.slurm_job_id,
+        }
+        for data_point in raw_data
+    ]
+
+    query = insert(JobSubmissionMetric).values(formatted_data)
+    await synth_session.execute(query)
+
+    inject_security_header("who@cares.com", permission, client_id="dummy-client")
+    response = await client.get(
+        f"/jobbergate/job-submissions/{inserted_job_submission_id}/metrics/timestamps"
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    response_data = response.json()
+    assert response_data == {
+        "max": max(formatted_data, key=lambda x: x["time"])["time"],
+        "min": min(formatted_data, key=lambda x: x["time"])["time"],
+    }
+
+
+@pytest.mark.parametrize(
+    "permission, job_submission_id",
+    [
+        (Permissions.ADMIN, 64537),
+        (Permissions.JOB_SUBMISSIONS_READ, 4967),
+    ],
+)
+async def job_submissions_metrics_timestamps__job_submission_not_found(
+    permission,
+    job_submission_id,
+    client,
+    inject_security_header,
+):
+    """
+    Test GET /job-submissions/{job_submission_id}/metrics/timestamps returns 404
+    when the job submission doesn't exist
+    """
+
+    inject_security_header("who@cares.com", permission, client_id="dummy-client")
+    response = await client.get(f"/jobbergate/job-submissions/{job_submission_id}/metrics/timestamps")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    response_data = response.json()
+    assert (
+        response_data["detail"]
+        == f"No metrics found for job submission {job_submission_id} or job submission does not exist"
+    )
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [
+        (Permissions.ADMIN,),
+        (Permissions.JOB_SUBMISSIONS_READ,),
+    ],
+)
+async def job_submissions_metrics_timestamps__job_submission_has_no_metric(
+    permission,
+    fill_job_script_data,
+    fill_job_submission_data,
+    client,
+    inject_security_header,
+    synth_services,
+):
+    """
+    Test GET /job-submissions/{job_submission_id}/metrics/timestamps returns 404 when
+    the job submission exists but has no metrics.
+    """
+    base_job_script = await synth_services.crud.job_script.create(**fill_job_script_data())
+
+    inserted_job_script_id = base_job_script.id
+
+    inserted_submission = await synth_services.crud.job_submission.create(
+        job_script_id=inserted_job_script_id,
+        **fill_job_submission_data(
+            client_id="dummy-client",
+            status=JobSubmissionStatus.SUBMITTED,
+            slurm_job_id=111,
+            slurm_job_state=SlurmJobState.PENDING,
+            slurm_job_info="Fake slurm job info",
+        ),
+    )
+    inserted_job_submission_id = inserted_submission.id
+
+    inject_security_header("who@cares.com", permission, client_id="dummy-client")
+    response = await client.get(
+        f"/jobbergate/job-submissions/{inserted_job_submission_id}/metrics/timestamps"
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    response_data = response.json()
+    assert (
+        response_data
+        == f"No metrics found for job submission {inserted_job_submission_id} or job submission does not exist"
+    )


### PR DESCRIPTION
This PR introduces an endpoint that retrieves the minimum and maximum timestamps of the metrics associated with a specific job submission. The endpoint returns 200 in case of successful request, otherwise 404 in case either the job submission doesn't exist or doesn't have any metrics
associated with it.