### PR TITLE
chore(agent,api): PENG-2592 adjust default values for sentry's sample rates.

### DIFF
--- a/jobbergate-agent/CHANGELOG.md
+++ b/jobbergate-agent/CHANGELOG.md
@@ -4,6 +4,7 @@ This file keeps track of all notable changes to jobbergate-agent
 
 ## Unreleased
 
+- Added custom settings for configuring Sentry's sample rates [[PENG-2592](https://sharing.clickup.com/t/h/c/18022949/PENG-2592/QQUQ1ABLAP6QSYX)]
 
 ## 5.4.2 -- 2024-12-16
 ## 5.4.1 -- 2024-12-13

--- a/jobbergate-agent/jobbergate_agent/settings.py
+++ b/jobbergate-agent/jobbergate_agent/settings.py
@@ -1,9 +1,9 @@
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Annotated, Optional
 
 import buzz
-from pydantic import AnyHttpUrl, Field, ValidationError, model_validator
+from pydantic import AnyHttpUrl, confloat, Field, ValidationError, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
 
@@ -36,6 +36,9 @@ class Settings(BaseSettings):
     # Sentry
     SENTRY_DSN: Optional[AnyHttpUrl] = None
     SENTRY_ENV: str = "local"
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, confloat(gt=0, le=1.0)] = 0.01
+    SENTRY_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.25
+    SENTRY_PROFILING_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.01
 
     # OIDC config for machine-to-machine security
     OIDC_DOMAIN: str

--- a/jobbergate-agent/jobbergate_agent/utils/sentry.py
+++ b/jobbergate-agent/jobbergate_agent/utils/sentry.py
@@ -15,7 +15,9 @@ def init_sentry():
         sentry_sdk.init(
             dsn=SETTINGS.SENTRY_DSN,
             integrations=[sentry_logging],
-            traces_sample_rate=1.0,
+            sample_rate=SETTINGS.SENTRY_SAMPLE_RATE,
+            profiles_sample_rate=SETTINGS.SENTRY_PROFILING_SAMPLE_RATE,
+            traces_sample_rate=SETTINGS.SENTRY_TRACES_SAMPLE_RATE,
             environment=SETTINGS.SENTRY_ENV,
             propagate_traces=False,  # Do not propagate traces to child processes (e.g. sbatch subprocesses)
         )

--- a/jobbergate-api/CHANGELOG.md
+++ b/jobbergate-api/CHANGELOG.md
@@ -4,6 +4,7 @@ This file keeps track of all notable changes to jobbergate-api
 
 ## Unreleased
 
+- Adjusted the default values for the Sentry's sample rates [[PENG-2592](https://sharing.clickup.com/t/h/c/18022949/PENG-2592/QQUQ1ABLAP6QSYX)]
 
 ## 5.4.2 -- 2024-12-16
 ## 5.4.1 -- 2024-12-13

--- a/jobbergate-api/jobbergate_api/config.py
+++ b/jobbergate-api/jobbergate_api/config.py
@@ -5,11 +5,11 @@ Pull settings from environment variables or a .env file if available.
 """
 
 from enum import Enum
-from typing import Optional
+from typing import Annotated, Optional
 
 from buzz import require_condition
 from loguru import logger
-from pydantic import Field, HttpUrl, model_validator
+from pydantic import confloat, Field, HttpUrl, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -89,9 +89,9 @@ class Settings(BaseSettings):
 
     # Sentry configuration
     SENTRY_DSN: Optional[HttpUrl] = None
-    SENTRY_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
-    SENTRY_PROFILING_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
-    SENTRY_TRACING_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, confloat(gt=0, le=1.0)] = 0.01
+    SENTRY_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.25
+    SENTRY_PROFILING_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.01
 
     # Maximum number of bytes allowed for file uploads
     MAX_UPLOAD_FILE_SIZE: int = 5 * 1024 * 1024  # 100 MB

--- a/jobbergate-api/jobbergate_api/main.py
+++ b/jobbergate-api/jobbergate_api/main.py
@@ -51,7 +51,7 @@ if settings.SENTRY_DSN and settings.DEPLOY_ENV.lower() != "test":
         sample_rate=settings.SENTRY_SAMPLE_RATE,
         environment=settings.DEPLOY_ENV,
         profiles_sample_rate=settings.SENTRY_PROFILING_SAMPLE_RATE,
-        traces_sample_rate=settings.SENTRY_TRACING_SAMPLE_RATE,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
     )
     subapp.add_middleware(SentryAsgiMiddleware)
 else:

--- a/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
+++ b/jobbergate-cli/tests/subapps/job_scripts/test_tools.py
@@ -182,6 +182,7 @@ def test_render_template__fail_when_unable_to_render(tmp_path):
     with pytest.raises(Abort, match="Unable to render"):
         render_template(template_path, parameters)
 
+
 def test_render_template__fail_sandbox_violation(tmp_path):
     template_path = tmp_path / "dummy.j2"
     template_path.write_text("{{ foo.__str__() }}")
@@ -190,6 +191,7 @@ def test_render_template__fail_sandbox_violation(tmp_path):
 
     with pytest.raises(Abort, match="Security errors raised when rendering"):
         render_template(template_path, parameters)
+
 
 def test_render_template__fails_if_template_does_not_exist(tmp_path):
     non_exist = tmp_path / "does/not/exist"


### PR DESCRIPTION
This PR modifies the default values for the following configurations:

* SENTRY_TRACES_SAMPLE_RATE
* SENTRY_SAMPLE_RATE
* SENTRY_PROFILING_SAMPLE_RATE

The values were adjusted acording to the task's acceptance criteria.