### PR TITLE
chore(jobbergate-agent): Set sensible defaults for jobbergate-agent

### DIFF
--- a/jobbergate-agent/jobbergate_agent/settings.py
+++ b/jobbergate-agent/jobbergate_agent/settings.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     DEFAULT_SLURM_WORK_DIR: Path = Path("/tmp")
 
     # cluster api info
-    BASE_API_URL: str = "https://armada-k8s.staging.omnivector.solutions"
+    BASE_API_URL: str = "https://apis.vantagehpc.io"
 
     # Sentry
     SENTRY_DSN: Optional[AnyHttpUrl] = None
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     SENTRY_PROFILING_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.01
 
     # OIDC config for machine-to-machine security
-    OIDC_DOMAIN: str
+    OIDC_DOMAIN: str = "auth.vantagehpc.io/realms/vantage"
     OIDC_CLIENT_ID: str
     OIDC_CLIENT_SECRET: str
     OIDC_USE_HTTPS: bool = True

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
@@ -28,7 +28,7 @@ class JobSubmission(CrudMixin, Base):
         slurm_job_id: The id of the job in the slurm queue.
         slurm_job_state: The Slurm Job state as reported by the agent
         slurm_job_info: Detailed information about the  Slurm Job as reported by the agent
-        client_id: The id of the custer this submission runs on.
+        client_id: The id of the cluster this submission runs on.
         status: The status of the job submission.
         report_message: The message returned by the job.
         sbatch_arguments: The arguments used to submit the job to the slurm queue.


### PR DESCRIPTION
Applied defaults for the `BASE_API_URL` and `OIDC_DOMAIN` to the defaults used for most production deploys of jobbergate-agent. This will make it even simpler to configure the agent for most applications.