### PR TITLE
ci: revert tag on merged PR to use PAT

### DIFF
--- a/.github/workflows/tag_on_merged_pull_request.yaml
+++ b/.github/workflows/tag_on_merged_pull_request.yaml
@@ -13,9 +13,6 @@ on:
       - release/**
     types: [closed]
 
-permissions:
-  contents: write
-
 jobs:
   create-tag:
     if: (github.event.pull_request.merged && startsWith(github.head_ref, 'prepare-release/'))
@@ -23,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TOKEN }}
 
       - uses: bluwy/substitute-string-action@v1
         name: Get Tag


### PR DESCRIPTION
When we use `GITHUB_TOKEN` in the actions, all of the interactions with the repository are on behalf of the Github-actions bot. The operations act by Github-actions bot cannot trigger a new workflow run. So, in our case, the tag created by `tag_on_merged_pull_request` won't trigger `release_on_tag`.