### PR TITLE
cherry-pick: remove the config *task-self-update-interval-seconds* from the snap

### DIFF
--- a/jobbergate-agent-snap/hooks/bin/configure
+++ b/jobbergate-agent-snap/hooks/bin/configure
@@ -18,7 +18,6 @@ AGENT_VARIABLES_MAP: dict[str, Union[str, int]] = {
     "OIDC_CLIENT_ID": "",
     "OIDC_CLIENT_SECRET": "",
     "TASK_JOBS_INTERVAL_SECONDS": 30,
-    "TASK_SELF_UPDATE_INTERVAL_SECONDS": 30,
     "CACHE_DIR": f"{SNAP_COMMON_PATH}/.cache",
     "SBATCH_PATH": "/usr/bin/sbatch",
     "SCONTROL_PATH": "/usr/bin/scontrol",

--- a/jobbergate-agent-snap/snap/snapcraft.yaml
+++ b/jobbergate-agent-snap/snap/snapcraft.yaml
@@ -19,8 +19,6 @@ description: |
 
   - task-jobs-interval-seconds: The interval in seconds at which the agent will run its internal task jobs, hence sending data to the Jobbergate API server. This is optional and defaults to 30 seconds.
 
-  - task-self-update-interval-seconds: The interval in seconds at which the agent will check for updates to itself. This is optional and defaults to 30 seconds (1 hour).
-
   - sbatch-path: The absolute path to the *sbatch* command on the host system. This is optional and defaults to /usr/bin/sbatch.
 
   - scontrol-path: The absolute path to the *scontrol* command on the host system. This is optional and defaults to /usr/bin/scontrol.


### PR DESCRIPTION
Original Commit: bd82566de10172bcae860492d5f3bde900438c30