### PR TITLE
cherry-pick(jobbergate-api): Removed the sa.Dialect type from alembic migration

### DIFF
--- a/jobbergate-api/alembic/versions/20241128_162020--99c3877d0f10_create_job_metric_table.py
+++ b/jobbergate-api/alembic/versions/20241128_162020--99c3877d0f10_create_job_metric_table.py
@@ -63,12 +63,12 @@ drop_materialized_view_template = "DROP MATERIALIZED VIEW {view_name}"
 class TimestampInt(TypeDecorator):
     impl = DateTime(timezone=True)
 
-    def process_bind_param(self, value: int | None, dialect: sa.Dialect) -> datetime | None:
+    def process_bind_param(self, value: int | None, dialect) -> datetime | None:
         if value is not None:
             return datetime.fromtimestamp(value, tz=timezone.utc)
         return value
 
-    def process_result_value(self, value: datetime | None, dialect: sa.Dialect) -> int | None:
+    def process_result_value(self, value: datetime | None, dialect) -> int | None:
         if value is not None:
             return int(value.timestamp())
         return value


### PR DESCRIPTION
Vantage API runs the migrations during the organization creation process. Due to an incompatibility between versions 1.4 and 2.0 of SQLalchmey used by vantage api, it was needed to remove the Dialect type from alembic migration.