### PR TITLE
fix(agent): update the `validate_job_state` validator to support data_parser 0.0.40

### DIFF
--- a/changes/agent/739.fixed.md
+++ b/changes/agent/739.fixed.md
@@ -1,0 +1,6 @@
+Updated the `validate_job_state` validator to support data_parser 0.0.40.
+
+In Slurm 24.11, the `--json` flag from the `scontrol show job` command uses the
+data_parser 0.0.40. According to the official [documentation](https://slurm.schedmd.com/job_state_codes.html#overview),
+the job flags can be returned alongside the job state, which can make the `job_state` key to have multiple keys. This
+change prevents any validation error when fetching job's data by returning the first available state.

--- a/jobbergate-agent/jobbergate_agent/jobbergate/schemas.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/schemas.py
@@ -89,8 +89,10 @@ class SlurmJobData(pydantic.BaseModel, extra="ignore"):
             return None
 
         if isinstance(value, list):
-            if len(value) != 1:
-                raise ValueError("job_state does not have exactly one value.")
+            if len(value) == 0:
+                raise ValueError("job_state does not have at least one value.")
+            # from data_parser 0.0.40, the Slurm API can return multiple states
+            # [Reference](https://slurm.schedmd.com/job_state_codes.html#overview)
             return value[0]
         return value
 

--- a/jobbergate-agent/tests/jobbergate/test_update.py
+++ b/jobbergate-agent/tests/jobbergate/test_update.py
@@ -119,7 +119,7 @@ async def test_fetch_job_data__handles_list_in_job_state():
 async def test_fetch_job_data__raises_error_if_job_state_is_invalid_list():
     """
     Test that the ``fetch_job_data()`` function raises an exception
-    if the list slurm_job_state does not have exactly one value.
+    if the list slurm_job_state does not have at least one value.
     """
     mocked_sbatch = mock.MagicMock()
     mocked_sbatch.get_job_info.return_value = dict(
@@ -129,7 +129,7 @@ async def test_fetch_job_data__raises_error_if_job_state_is_invalid_list():
         foo="bar",
     )
 
-    with pytest.raises(SbatchError, match="does not have exactly one value"):
+    with pytest.raises(SbatchError, match="does not have at least one value"):
         await fetch_job_data(123, mocked_sbatch)
 
 


### PR DESCRIPTION
This PR modifies the validator function `validate_job_state` from the `SlurmJobData` model in order to support the data_parser 0.0.40.

Essentialy, in Slurm 24.11, the `--json` flag from the `scontrol show job` command uses the data_parser 0.0.40. According to the official [documentation](https://slurm.schedmd.com/job_state_codes.html#overview), the job flags can be returned alongside the job state, which can make the `job_state` key to have multiple keys.