### PR TITLE
fix(agent): prevent int64 overflow from values fecthed from InfluxDB.

### DIFF
--- a/changes/agent/740.fixed.md
+++ b/changes/agent/740.fixed.md
@@ -1,0 +1,1 @@
+Adjusted the `fetch_influx_data` function to return a measurement value 0 when the original value overflows the maximum int64 value.

--- a/jobbergate-agent/jobbergate_agent/jobbergate/update.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/update.py
@@ -124,7 +124,7 @@ async def fetch_influx_data(
                 job=point["job"],
                 step=point["step"],
                 task=point["task"],
-                value=point["value"],
+                value=point["value"] if point["value"] < 2**63 - 1 else 0,  # prevent int64 overflow
                 measurement=measurement,
             )
             for point in result.get_points()


### PR DESCRIPTION
This commit modifies the `fetch_influx_data` function to return 0 in the measurement value and the original value is bigger than 2^63 - 1. This prevents an error in the API where the value is bigger than int64, causing the metrics to not be stored in the database.