### PR TITLE
fix(agent): [PENG-2912] constrain the measurements returned by the `fetch_influx_measurements` function.

### DIFF
--- a/changes/agent/+c829d5e8.changed.md
+++ b/changes/agent/+c829d5e8.changed.md
@@ -1,0 +1,4 @@
+Harden the `fetch_influx_measurements` function to only return the measurements defined in the `INFLUXDB_MEASUREMENT` constant.
+
+This is necessary because some Slurm clusters might have other measurements enabled, which leads to an error when the agent
+sends the metrics to the API.

--- a/jobbergate-agent/jobbergate_agent/jobbergate/schemas.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/schemas.py
@@ -105,6 +105,14 @@ class InfluxDBMeasurementDict(TypedDict):
     name: INFLUXDB_MEASUREMENT
 
 
+class InfluxDBGenericMeasurementDict(TypedDict):
+    """
+    Map a generic entry in the list returned by `InfluxDBClient(...).get_list_measurements(...)`.
+    """
+
+    name: str
+
+
 class InfluxDBPointDict(TypedDict):
     """
     Map each entry in the generator returned by InfluxDBClient(...).query(...).get_points().


### PR DESCRIPTION
This PR modifies the behaviour of the `fetch_influx_measurements` function in order to only return the measurements defined in the `INFLUXDB_MEASUREMENT` constant. This is necessary becase some Slurm clusters may have other measurements, which leads to an error when the agent sends the metrics to the API.