### PR TITLE
fix(core): remove check for submission dir existence

### DIFF
--- a/changes/core/755.fixed.md
+++ b/changes/core/755.fixed.md
@@ -1,0 +1,1 @@
+Removed the check for existence of the submission directory

--- a/jobbergate-core/jobbergate_core/tools/sbatch.py
+++ b/jobbergate-core/jobbergate_core/tools/sbatch.py
@@ -117,7 +117,6 @@ class SubmissionHandler:
             check(self.sbatch_path.is_absolute(), "sbatch_path is not an absolute path")
             check(self.sbatch_path.exists(), "sbatch_path does not exist")
             check(self.submission_directory.is_absolute(), "submission_directory is not an absolute path")
-            check(self.submission_directory.exists(), "submission_directory does not exist")
 
     def submit_job(self, job_script_path: Path) -> int:
         """Runs sbatch as the user to submit a job script and returns the slurm id assigned to it."""


### PR DESCRIPTION
The agent can face errors when running `pathlib.Path().exists()` since the user running it can have different permissions on the directory than the submitting user. Agent and CLI both check this in advance, so there is no need for it on core.