### PR TITLE
fix(agent): patched pagination logic to handle empty responses

### DIFF
--- a/changes/agent/765.fixed.md
+++ b/changes/agent/765.fixed.md
@@ -1,0 +1,1 @@
+Patched pagination logic when handling an empty list os entries

--- a/jobbergate-agent/jobbergate_agent/jobbergate/pagination.py
+++ b/jobbergate-agent/jobbergate_agent/jobbergate/pagination.py
@@ -34,7 +34,7 @@ async def fetch_paginated_result(url: str, base_model: Type[T]) -> list[T]:
     for page in range(1, SETTINGS.MAX_PAGES_PER_CYCLE + 1):
         page_entries = await fetch_page(url, base_model, page)
         results.extend(page_entries.items)
-        if page_entries.pages == page_entries.page:
+        if page_entries.page >= page_entries.pages:
             break
 
     return results


### PR DESCRIPTION
The API actually says `pages=0` when returning an empty list of entries.