### PR TITLE
chore(api): add the `slurm_job_state` column as a sortable field in the `JobSubmission` model.

### DIFF
--- a/changes/api/+9f66d51f.added.md
+++ b/changes/api/+9f66d51f.added.md
@@ -1,0 +1,1 @@
+Added the field `slurm_job_state` as a sortable column in the `JobSubmission` model.

--- a/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
+++ b/jobbergate-api/jobbergate_api/apps/job_submissions/models.py
@@ -107,6 +107,7 @@ class JobSubmission(CrudMixin, Base):
             cls.slurm_job_id,
             cls.client_id,
             cls.status,
+            cls.slurm_job_state,
             *super().sortable_fields(),
         }
 


### PR DESCRIPTION
This PR introduces a slightly change in the `JobSubmission` model in order to add the `slurm_job_state` as a sortable column.