### PR TITLE
[main] fix(cli): update typer to version 0.16.0 to make it compatible with click 8.2

### DIFF
--- a/changes/cli/796.fixed.md
+++ b/changes/cli/796.fixed.md
@@ -1,0 +1,1 @@
+Bumped Typer to `^0.16.0` to patch compatibility issue when running with Click `<8.2`

--- a/jobbergate-cli/poetry.lock
+++ b/jobbergate-cli/poetry.lock
@@ -510,7 +510,7 @@ ansicon = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "jobbergate-core"
-version = "5.7.0a0"
+version = "5.7.0a1"
 description = "Jobbergate Core"
 optional = false
 python-versions = "^3.10"
@@ -1594,14 +1594,14 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.12.3"
+version = "0.16.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "typer-0.12.3-py3-none-any.whl", hash = "sha256:070d7ca53f785acbccba8e7d28b08dcd88f79f1fbda035ade0aecec71ca5c914"},
-    {file = "typer-0.12.3.tar.gz", hash = "sha256:49e73131481d804288ef62598d97a1ceef3058905aa536a1134f90891ba35482"},
+    {file = "typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855"},
+    {file = "typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b"},
 ]
 
 [package.dependencies]
@@ -1723,4 +1723,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "21989b494e5a06f9489d916d2f3e1aeb4a7b6f700b8d1cde666916568c73aa39"
+content-hash = "61948cacf70adf084e86a601ccebd13b3f6182b2c6cea71b265df70c9e3f69b7"

--- a/jobbergate-cli/pyproject.toml
+++ b/jobbergate-cli/pyproject.toml
@@ -31,7 +31,7 @@ python-dotenv = "^1.0.0"
 PyYAML = "6.*"
 rich = "^11.2.0"
 sentry-sdk = "^2.29.1"
-typer = "^0.12.3"
+typer = "^0.16.0"
 pydantic = "^2.7"
 pydantic-settings = "^2.3.3"
 


### PR DESCRIPTION
 Backport 46d2d28ac06d2902600ec73e2ebf23f5cf5cf27d from #796.