### PR TITLE
Revert "chore: update Poetry version to 2.1.1 (#788)"

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
         with:
-          poetry-version: 2.1.1
+          poetry-version: 1.5.1
 
       - name: Build Documentation
         working-directory: jobbergate-docs

--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: Gr1N/setup-poetry@v8
         with:
-          poetry-version: 2.1.1
+          poetry-version: 1.5.1
 
       - id: api-package
         name: Bump version on the API

--- a/.github/workflows/publish_on_tag.yaml
+++ b/.github/workflows/publish_on_tag.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: Gr1N/setup-poetry@v8
         with:
-          poetry-version: 2.1.1
+          poetry-version: 1.5.1
 
       - id: poetry-package-version
         name: Get project's version
@@ -97,7 +97,7 @@ jobs:
 
       - uses: Gr1N/setup-poetry@v8
         with:
-          poetry-version: 2.1.1
+          poetry-version: 1.5.1
 
       - id: poetry-package-version
         name: Get version of project from poetry

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Gr1N/setup-poetry@v8
         with:
-          poetry-version: 2.1.1
+          poetry-version: 1.5.1
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Gr1N/setup-poetry@v8
         with:
-          poetry-version: 2.1.1
+          poetry-version: 1.5.1
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Gr1N/setup-poetry@v8
         with:
-          poetry-version: 2.1.1
+          poetry-version: 1.5.1
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/jobbergate-api/Dockerfile
+++ b/jobbergate-api/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apt update && apt install -y curl libpq-dev gcc
 
-RUN pip install poetry==2.1.1
+RUN pip install poetry==1.5.1
 
 COPY ./pyproject.toml ./poetry.lock /app
 

--- a/jobbergate-api/Dockerfile-dev
+++ b/jobbergate-api/Dockerfile-dev
@@ -3,7 +3,7 @@ FROM python:3.11-slim-buster
 RUN apt update && apt install -y curl libpq-dev gcc make
 
 RUN curl -sSL https://install.python-poetry.org | \
-POETRY_HOME=/opt/poetry POETRY_VERSION=2.1.1 python && \
+POETRY_HOME=/opt/poetry POETRY_VERSION=1.5.1 python && \
 cd /usr/local/bin && \
 ln -s /opt/poetry/bin/poetry && \
 poetry config virtualenvs.create false

--- a/jobbergate-cli/Dockerfile
+++ b/jobbergate-cli/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apt update && apt install -y curl libpq-dev gcc
 
 RUN curl -sSL  https://install.python-poetry.org | \
-    POETRY_HOME=/opt/poetry POETRY_VERSION=2.1.1 python && \
+    POETRY_HOME=/opt/poetry POETRY_VERSION=1.5.1 python && \
     ln -s /opt/poetry/bin/poetry /usr/local/bin/poetry && \
     poetry config virtualenvs.create false
 

--- a/jobbergate-composed/Dockerfile-slurm
+++ b/jobbergate-composed/Dockerfile-slurm
@@ -64,7 +64,7 @@ RUN apt update && apt install -y curl libpq-dev gcc python3-dev python3-pip && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 RUN curl -sSL  https://install.python-poetry.org | \
-    POETRY_HOME=/opt/poetry POETRY_VERSION=2.1.1 python && \
+    POETRY_HOME=/opt/poetry POETRY_VERSION=1.5.1 python && \
     ln -s /opt/poetry/bin/poetry /usr/local/bin/poetry && \
     poetry config virtualenvs.create false
 


### PR DESCRIPTION
This update makes release to pypi break since `poetry-stickywheel-plugin` is not compatible with Poetry 2. So I'm reverting the change while we wait for https://github.com/artisanofcode/poetry-stickywheel-plugin/pull/30.

This reverts commit 25f22ec871e350d63904ba8d06953881901162d2.