### PR TITLE
chore(snap): PENG-3083 add Sentry configs in the snap.

### DIFF
--- a/changes/agent-snap/+9a852d99.added.md
+++ b/changes/agent-snap/+9a852d99.added.md
@@ -1,0 +1,1 @@
+Modified the `configure` hook of the snap so it is possible to configure Sentry variables to enable proper tracing in the agent.

--- a/jobbergate-agent-snap/README.md
+++ b/jobbergate-agent-snap/README.md
@@ -36,6 +36,18 @@ The optional values are:
 
 - write-submission-files: A boolean value (true, false) that indicates whether the agent should write submission files to disk. This is optional and defaults to false.
 
+Sentry's configuration:
+
+- sentry-dsn: The Sentry DSN in case you want to enable error reporting to Sentry. This is optional and defaults to an empty string.
+
+- sentry-env: The Sentry environment in case you want to enable error reporting to Sentry. This is optional and defaults to `snap-env`.
+
+- sentry-traces-sample-rate: The Sentry traces sample rate in case you want to enable error reporting to Sentry. This is optional and defaults to `0.01`.
+
+- sentry-sample-rate: The Sentry sample rate in case you want to enable error reporting to Sentry. This is optional and defaults to `0.25`.
+
+- sentry-profiling-sample-rate: The Sentry profiling sample rate in case you want to enable error reporting to Sentry. This is optional and defaults to `0.01`.
+
 Any configuration can be set using the *snap* command line, e.g.:
 ```bash
 sudo snap set jobbergate-agent oidc-client-id=foo

--- a/jobbergate-agent-snap/hooks/bin/configure
+++ b/jobbergate-agent-snap/hooks/bin/configure
@@ -31,6 +31,11 @@ AGENT_VARIABLES_MAP: dict[str, Union[str, int]] = {
     "INFLUX_TIMEOUT": "",
     "INFLUX_UDP_PORT": 4444,
     "INFLUX_CERT_PATH": "",
+    "SENTRY_DSN": "",
+    "SENTRY_ENV": "snap-env",
+    "SENTRY_TRACES_SAMPLE_RATE": "0.01",
+    "SENTRY_SAMPLE_RATE": "0.25",
+    "SENTRY_PROFILING_SAMPLE_RATE": "0.01",
 }
 
 

--- a/jobbergate-agent-snap/snap/snapcraft.yaml
+++ b/jobbergate-agent-snap/snap/snapcraft.yaml
@@ -45,6 +45,16 @@ description: |
 
   - influx-cert-path: The absolute path to the SSL certificate that the agent will use to connect to the InfluxDB server. This is optional and defaults to none.
 
+  - sentry-dsn: The Sentry DSN in case you want to enable error reporting to Sentry. This is optional and defaults to an empty string.
+
+  - sentry-env: The Sentry environment in case you want to enable error reporting to Sentry. This is optional and defaults to `snap-env`.
+
+  - sentry-traces-sample-rate: The Sentry traces sample rate in case you want to enable error reporting to Sentry. This is optional and defaults to `0.01`.
+
+  - sentry-sample-rate: The Sentry sample rate in case you want to enable error reporting to Sentry. This is optional and defaults to `0.25`.
+
+  - sentry-profiling-sample-rate: The Sentry profiling sample rate in case you want to enable error reporting to Sentry. This is optional and defaults to `0.01`.
+
   For learning more about Jobbergate and how it can be used on Vantage, please visit https://docs.vantagehpc.io
 
 grade: stable
@@ -69,8 +79,8 @@ parts:
     build-attributes:
     - enable-patchelf
     override-stage: |
-     craftctl default
-     craftctl set version="$($SNAPCRAFT_PART_INSTALL/bin/python3 -m pip show jobbergate-agent | grep Version | awk '{print $2}')"
+      craftctl default
+      craftctl set version="$($SNAPCRAFT_PART_INSTALL/bin/python3 -m pip show jobbergate-agent | grep Version | awk '{print $2}')"
 
   hooks:
     plugin: dump


### PR DESCRIPTION
This PR modifies the `configure` hook of the snap so it is possible to configure Sentry variables to enable proper tracing in the agent.