### PR TITLE
fix(snap): correct the number of characters in the description.

### DIFF
--- a/changes/agent-snap/+db82aad0.fixed.md
+++ b/changes/agent-snap/+db82aad0.fixed.md
@@ -1,0 +1,1 @@
+Adjusted the number of characters in the snap description.

--- a/jobbergate-agent-snap/snap/snapcraft.yaml
+++ b/jobbergate-agent-snap/snap/snapcraft.yaml
@@ -5,8 +5,7 @@ summary: The Jobbergate Agent snap
 adopt-info: jobbergate-agent
 license: MIT
 description: |
-  The Jobbergate Agent Snap deploys the Jobbergate Agent Python package on your host system. This agent
-  is an essencial component of the Jobbergate platform for managing and submitting jobs to HPC clusters.
+  The Jobbergate Agent Snap deploys the Jobbergate Agent Python package on your host system.
 
   This snap requires a few configuration values to be set before it can be used. These values are:
   - base-api-url: The URL of the Jobbergate API server where the agent will send its data. Setting/unsetting this value is more interesting when using the snap in a development environment; do not change it otherwise.


### PR DESCRIPTION
This PR fixes an error found on the [CD workflow](https://github.com/omnivector-solutions/jobbergate/actions/runs/16197196862/job/45726695990). It adjusts the number of characters of the snap's description to be less than 4096.