### PR TITLE
feat(agent): add extra user groups on job-submission

### DIFF
--- a/changes/agent/837.added.md
+++ b/changes/agent/837.added.md
@@ -1,0 +1,1 @@
+Added the possibility to run subprocesses as the user using their multiple groups they belong to, so remote job submissions work on filesystems that rely on multiple group settings for granular access controls

--- a/jobbergate-agent/jobbergate_agent/settings.py
+++ b/jobbergate-agent/jobbergate_agent/settings.py
@@ -65,6 +65,7 @@ class Settings(BaseSettings):
 
     # Job submission settings
     WRITE_SUBMISSION_FILES: bool = True
+    GET_EXTRA_GROUPS: bool = False
 
     # InfluxDB settings for job metric collection
     INFLUX_DSN: Optional[AnyUrl] = Field(


### PR DESCRIPTION
Added the possibility to run subprocesses as the user using their multiple groups. It enables remote job submissions to work on filesystem that rely on multiple group settings for granular access controls.