### PR TITLE
fix(jobbergate-agent): upgrade apscheduler to 4.0.0a6

### DIFF
--- a/jobbergate-agent/jobbergate_agent/internals/update.py
+++ b/jobbergate-agent/jobbergate_agent/internals/update.py
@@ -2,15 +2,11 @@ import re
 import subprocess
 import sys
 from importlib.metadata import version
-from typing import TYPE_CHECKING
 
 from loguru import logger
 
 from jobbergate_agent.clients.cluster_api import backend_client as jobbergate_api_client
-from jobbergate_agent.utils.scheduler import schedule_tasks, scheduler
-
-if TYPE_CHECKING:
-    from apscheduler.job import Job
+from jobbergate_agent.utils.scheduler import clear_schedules, schedule_tasks, scheduler  # noqa: F401
 
 package_name = "jobbergate_agent"
 
@@ -85,23 +81,15 @@ async def self_update_agent() -> None:
     if _need_update(current_version, upstream_version):
         logger.warning("The Jobbergate Agent is outdated in relation to the upstream version; an update is required.")
 
-        logger.debug("Pausing the scheduler...")
-        scheduler.pause()
-
-        logger.debug("Clearing the scheduler jobs...")
-        scheduler_jobs: list[Job] = scheduler.get_jobs()
-        for job in scheduler_jobs:
-            job.remove()
+        logger.debug("Clearing existing schedules...")
+        await clear_schedules(scheduler)
 
         logger.debug(f"Updating {package_name} from version {current_version} to {upstream_version}...")
         _update_package(upstream_version)
         logger.debug("Update completed successfully.")
 
         logger.debug(f"Loading plugins from version {upstream_version}...")
-        schedule_tasks(scheduler)
-        scheduler.resume()
-        logger.debug("Plugins loaded successfully.")
-
-        logger.info("Resuming the scheduler")
+        await schedule_tasks(scheduler)
+        logger.debug("Plugins loaded and schedules re-registered.")
     else:
         logger.debug("No update is required or update crosses a major version divide.")

--- a/jobbergate-agent/jobbergate_agent/main.py
+++ b/jobbergate-agent/jobbergate_agent/main.py
@@ -1,19 +1,20 @@
 import asyncio
 
 from jobbergate_agent.utils.logging import logger
-from jobbergate_agent.utils.scheduler import init_scheduler, scheduler, shut_down_scheduler
+from jobbergate_agent.utils.scheduler import schedule_tasks, scheduler
 from jobbergate_agent.utils.sentry import init_sentry
 
 
-async def helper():
+async def run_scheduler():
     """
-    Based on example from the scheduler documentation:
+    Start the scheduler, register all task plugins, then run until stopped.
 
-    https://github.com/agronholm/apscheduler/blob/3.x/examples/schedulers/asyncio_.py
+    References:
+        https://github.com/agronholm/apscheduler/blob/master/examples/
     """
-    init_scheduler()
-    while True:
-        await asyncio.sleep(1000)
+    async with scheduler:
+        await schedule_tasks(scheduler)
+        await scheduler.run_until_stopped()
 
 
 def main():
@@ -21,12 +22,11 @@ def main():
     init_sentry()
     with asyncio.Runner() as runner:
         try:
-            runner.run(helper())
+            runner.run(run_scheduler())
         except (KeyboardInterrupt, SystemExit):
             logger.info("Jobbergate-agent is shutting down...")
         except Exception as err:
             logger.critical(f"Unexpected error in main event loop: {err}", exc_info=True)
             raise
-        finally:
-            shut_down_scheduler(scheduler, wait=False)
     logger.info("Jobbergate-agent has been stopped")
+

--- a/jobbergate-agent/jobbergate_agent/tasks.py
+++ b/jobbergate-agent/jobbergate_agent/tasks.py
@@ -1,41 +1,53 @@
 """Task definitions for the Jobbergate Agent."""
 
+from typing import Optional
+
+from apscheduler import AsyncScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
 from jobbergate_agent.internals.update import self_update_agent
 from jobbergate_agent.jobbergate.report_health import report_health_status
 from jobbergate_agent.jobbergate.submit import submit_pending_jobs
 from jobbergate_agent.jobbergate.update import update_active_jobs
 from jobbergate_agent.settings import SETTINGS
-from jobbergate_agent.utils.scheduler import BaseScheduler, Job
 
 
-def self_update_task(scheduler: BaseScheduler) -> Job:
+async def self_update_task(scheduler: AsyncScheduler) -> Optional[str]:
     """
     Schedule a task to self update the agent every ``TASK_SELF_UPDATE_INTERVAL_SECONDS`` seconds.
     """
     if SETTINGS.TASK_SELF_UPDATE_INTERVAL_SECONDS is None:
         return None
-    return scheduler.add_job(self_update_agent, "interval", seconds=SETTINGS.TASK_SELF_UPDATE_INTERVAL_SECONDS)
+    return await scheduler.add_schedule(
+        self_update_agent, IntervalTrigger(seconds=SETTINGS.TASK_SELF_UPDATE_INTERVAL_SECONDS)
+    )
 
 
-def active_submissions_task(scheduler: BaseScheduler) -> Job:
+async def active_submissions_task(scheduler: AsyncScheduler) -> str:
     """
     Schedule a task to handle active jobs every ``TASK_JOBS_INTERVAL_SECONDS`` seconds.
     """
-    return scheduler.add_job(update_active_jobs, "interval", seconds=SETTINGS.TASK_JOBS_INTERVAL_SECONDS)
+    return await scheduler.add_schedule(
+        update_active_jobs, IntervalTrigger(seconds=SETTINGS.TASK_JOBS_INTERVAL_SECONDS)
+    )
 
 
-def pending_submissions_task(scheduler: BaseScheduler) -> Job:
+async def pending_submissions_task(scheduler: AsyncScheduler) -> str:
     """
     Schedule a task to submit pending jobs every ``TASK_JOBS_INTERVAL_SECONDS`` seconds.
     """
-    return scheduler.add_job(submit_pending_jobs, "interval", seconds=SETTINGS.TASK_JOBS_INTERVAL_SECONDS)
+    return await scheduler.add_schedule(
+        submit_pending_jobs, IntervalTrigger(seconds=SETTINGS.TASK_JOBS_INTERVAL_SECONDS)
+    )
 
 
-def status_report_task(scheduler: BaseScheduler) -> Job:
+async def status_report_task(scheduler: AsyncScheduler) -> str:
     """
     Schedule a task to report the status.
     """
     seconds_between_calls = SETTINGS.TASK_JOBS_INTERVAL_SECONDS
-    return scheduler.add_job(
-        report_health_status, "interval", seconds=seconds_between_calls, kwargs={"interval": seconds_between_calls}
+    return await scheduler.add_schedule(
+        report_health_status,
+        IntervalTrigger(seconds=seconds_between_calls),
+        kwargs={"interval": seconds_between_calls},
     )

--- a/jobbergate-agent/jobbergate_agent/utils/scheduler.py
+++ b/jobbergate-agent/jobbergate_agent/utils/scheduler.py
@@ -8,28 +8,27 @@ References:
     https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins
 """
 
-from typing import Protocol
+from typing import Optional, Protocol
 
-from apscheduler.job import Job
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.schedulers.base import BaseScheduler
+from apscheduler import AsyncScheduler
 from buzz import handle_errors
 
 from jobbergate_agent.utils.logging import logger, logger_wraps
 from jobbergate_agent.utils.plugin import load_plugins
 
-scheduler = AsyncIOScheduler()
+
+scheduler = AsyncScheduler()
+
+# Track schedule IDs so they can be cleared during self-update
+_schedule_ids: list[str] = []
 
 
 class JobbergateTask(Protocol):
     """Protocol to be implemented by any task that is expected to run on the scheduler."""
 
-    def __call__(self, scheduler: BaseScheduler) -> Job | None:
+    async def __call__(self, scheduler: AsyncScheduler) -> Optional[str]:
         """
-        Specify a callable used to schedule a task and return the resulting job.
-
-        This is handled to client code to give them the opportunity to handle
-        their own configuration and to access the rich flexibility of the scheduler API.
+        Specify an async callable used to schedule a task and return the resulting schedule ID.
 
         None can also be returned if no task is going to be scheduled due to internal business logic.
         """
@@ -37,8 +36,9 @@ class JobbergateTask(Protocol):
 
 
 @logger_wraps()
-def schedule_tasks(scheduler: BaseScheduler) -> None:
-    """Discovery and schedule all tasks to be run by the agent."""
+async def schedule_tasks(scheduler: AsyncScheduler) -> None:
+    """Discover and schedule all tasks to be run by the agent."""
+    global _schedule_ids
 
     for name, task_function in load_plugins("tasks").items():
         with handle_errors(
@@ -46,21 +46,21 @@ def schedule_tasks(scheduler: BaseScheduler) -> None:
             raise_exc_class=RuntimeError,
             do_except=lambda params: logger.error(params.final_message),
         ):
-            job = task_function(scheduler=scheduler)
+            schedule_id = await task_function(scheduler=scheduler)
 
-        if job is not None:
-            job.name = name
-
-
-@logger_wraps()
-def init_scheduler() -> BaseScheduler:
-    """Initialize the scheduler and schedule all tasks."""
-    scheduler.start()
-    schedule_tasks(scheduler)
-    return scheduler
+        if schedule_id is not None:
+            _schedule_ids.append(schedule_id)
+            logger.debug(f"Scheduled task {name!r} with schedule ID {schedule_id}")
 
 
 @logger_wraps()
-def shut_down_scheduler(scheduler: BaseScheduler, wait: bool = True) -> None:
-    """Shutdown the scheduler."""
-    scheduler.shutdown(wait)
+async def clear_schedules(scheduler: AsyncScheduler) -> None:
+    """Remove all tracked schedules (used during self-update)."""
+    global _schedule_ids
+
+    for sid in list(_schedule_ids):
+        try:
+            await scheduler.remove_schedule(sid)
+        except Exception as exc:
+            logger.warning(f"Could not remove schedule {sid}: {exc}")
+    _schedule_ids.clear()

--- a/jobbergate-agent/pyproject.toml
+++ b/jobbergate-agent/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "jobbergate-core",
-    "apscheduler==3.11.2",
+    "apscheduler==4.0.0a6",
     "auto-name-enum>=3.0.0",
     "certifi>=2024.0.0",
     "influxdb>=5.3.2",

--- a/jobbergate-agent/tests/internals/test_update.py
+++ b/jobbergate-agent/tests/internals/test_update.py
@@ -119,11 +119,11 @@ def test_update_package(mocked_sys: mock.MagicMock, mocked_subprocess: mock.Magi
 @mock.patch("jobbergate_agent.internals.update._update_package")
 @mock.patch("jobbergate_agent.internals.update.version")
 @mock.patch("jobbergate_agent.internals.update._need_update")
-@mock.patch("jobbergate_agent.internals.update.scheduler")
-@mock.patch("jobbergate_agent.internals.update.schedule_tasks")
+@mock.patch("jobbergate_agent.internals.update.clear_schedules", new_callable=mock.AsyncMock)
+@mock.patch("jobbergate_agent.internals.update.schedule_tasks", new_callable=mock.AsyncMock)
 async def test_self_update_agent(
-    mocked_schedule_tasks: mock.MagicMock,
-    mocked_scheduler: mock.MagicMock,
+    mocked_schedule_tasks: mock.AsyncMock,
+    mocked_clear_schedules: mock.AsyncMock,
     mocked_need_update: mock.MagicMock,
     mocked_version: mock.MagicMock,
     mocked_update_package: mock.MagicMock,
@@ -134,14 +134,12 @@ async def test_self_update_agent(
 ):
     """Test that self_update_agent runs without error the expected logic.
 
-    If an update is available, it is expected that the scheduler is shutdown
-    and then restarted with the new version after the package update is done.
+    If an update is available, it is expected that existing schedules are cleared,
+    the package updated, and tasks re-registered.
     """
     mocked_version.return_value = current_version
     mocked_fetch_upstream_version_info.return_value = upstream_version
     mocked_need_update.return_value = is_update_available
-    mocked_scheduler.pause = mock.Mock()
-    mocked_scheduler.resume = mock.Mock()
 
     await self_update_agent()
 
@@ -149,13 +147,10 @@ async def test_self_update_agent(
     mocked_fetch_upstream_version_info.assert_called_once_with()
     mocked_need_update.assert_called_once_with(current_version, upstream_version)
     if is_update_available:
-        mocked_scheduler.pause.assert_called_once_with()
+        mocked_clear_schedules.assert_called_once()
         mocked_update_package.assert_called_once_with(upstream_version)
-        mocked_schedule_tasks.assert_called_once_with(mocked_scheduler)
-        mocked_scheduler.resume.assert_called_once_with()
-
+        mocked_schedule_tasks.assert_called_once()
     else:
-        mocked_scheduler.pause.assert_not_called()
+        mocked_clear_schedules.assert_not_called()
         mocked_update_package.assert_not_called()
         mocked_schedule_tasks.assert_not_called()
-        mocked_scheduler.resume.assert_not_called()

--- a/jobbergate-agent/tests/test_main.py
+++ b/jobbergate-agent/tests/test_main.py
@@ -7,10 +7,8 @@ def test_main_logs_and_handles_exceptions(monkeypatch, caplog):
     caplog.set_level(logging.INFO)
     # Patch dependencies
     monkeypatch.setattr(main_mod, "init_sentry", lambda: None)
-    monkeypatch.setattr(main_mod, "shut_down_scheduler", lambda s, wait: None)
-    monkeypatch.setattr(main_mod, "scheduler", object())
-    # Patch helper to avoid infinite loop
-    monkeypatch.setattr(main_mod, "helper", lambda: "fake-coro")
+    # Patch run_scheduler to avoid actually starting the scheduler
+    monkeypatch.setattr(main_mod, "run_scheduler", lambda: "fake-coro")
 
     # Patch asyncio.Runner
     class DummyRunner:

--- a/jobbergate-agent/tests/utils.py/test_scheduler.py
+++ b/jobbergate-agent/tests/utils.py/test_scheduler.py
@@ -1,42 +1,44 @@
 from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
 
 from jobbergate_agent.utils.scheduler import (
-    AsyncIOScheduler,
+    AsyncScheduler,
     load_plugins,
     schedule_tasks,
 )
 
 
+@pytest.mark.asyncio
 @mock.patch("jobbergate_agent.utils.scheduler.load_plugins")
-def test_schedule_tasks__success(mocked_plugins):
+async def test_schedule_tasks__success(mocked_plugins):
     """Test that schedule_tasks returns the expected result."""
 
     discovered_functions = load_plugins("tasks")
-    mocked_functions = {name: mock.Mock() for name in discovered_functions.keys()}
+    mocked_functions = {name: AsyncMock(return_value="fake-schedule-id") for name in discovered_functions.keys()}
 
     mocked_plugins.return_value = mocked_functions
 
-    scheduler = AsyncIOScheduler()
-    schedule_tasks(scheduler)
+    async with AsyncScheduler() as scheduler:
+        await schedule_tasks(scheduler)
 
     mocked_plugins.assert_called_once_with("tasks")
     assert all(m.call_count == 1 for m in mocked_functions.values())
     assert all(m.call_args(scheduler=scheduler) for m in mocked_functions.values())
 
 
+@pytest.mark.asyncio
 @mock.patch("jobbergate_agent.utils.scheduler.load_plugins")
-def test_schedule_tasks__fails(mocked_plugins):
+async def test_schedule_tasks__fails(mocked_plugins):
     """Test that schedule_tasks raises RuntimeError when fails to schedule a task."""
 
-    mocked_functions = {"supposed-to-fail": mock.Mock(side_effect=Exception("Test"))}
+    mocked_functions = {"supposed-to-fail": AsyncMock(side_effect=Exception("Test"))}
 
     mocked_plugins.return_value = mocked_functions
 
-    scheduler = AsyncIOScheduler()
-
-    with pytest.raises(RuntimeError, match="^Failed to execute"):
-        schedule_tasks(scheduler)
+    async with AsyncScheduler() as scheduler:
+        with pytest.raises(RuntimeError, match="^Failed to execute"):
+            await schedule_tasks(scheduler)
 
     mocked_plugins.assert_called_once_with("tasks")

--- a/uv.lock
+++ b/uv.lock
@@ -288,14 +288,17 @@ wheels = [
 
 [[package]]
 name = "apscheduler"
-version = "3.11.2"
+version = "4.0.0a6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
+    { name = "attrs" },
+    { name = "tenacity" },
     { name = "tzlocal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/7f/ca0404dac83438b5dcb75c797092381040320be84f3af098cf9a486529e0/apscheduler-4.0.0a6.tar.gz", hash = "sha256:5134617c028f097de4a09abbeefc42625cb0ce3adcb4ce49d74cc26054084761", size = 3116644, upload-time = "2025-04-27T08:36:22.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bd/35b5691919859a906cd098d62e2a1399cb8ede3e05b6480cf15d472ad5b1/apscheduler-4.0.0a6-py3-none-any.whl", hash = "sha256:87031f7537aaa6ea2d3e69fdd9454b641f18938fc8cd0c589972006eceba8ee9", size = 88115, upload-time = "2025-04-27T08:36:20.315Z" },
 ]
 
 [[package]]
@@ -1202,7 +1205,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apscheduler", specifier = "==3.11.2" },
+    { name = "apscheduler", specifier = "==4.0.0a6" },
     { name = "auto-name-enum", specifier = ">=3.0.0" },
     { name = "certifi", specifier = ">=2024.0.0" },
     { name = "influxdb", specifier = ">=5.3.2" },
@@ -3053,6 +3056,15 @@ wheels = [
 [package.optional-dependencies]
 widechars = [
     { name = "wcwidth" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upgrades `apscheduler` from `3.11.2` to `4.0.0a6` in `jobbergate-agent`. This is required to align with the `license-manager-agent` dependency and allow both agents to share a single Python virtual environment in the `vantage-agent-snap` deployment.

APScheduler 4.x has a substantially different async API and is fully compatible with Python 3.14 (the 3.x API uses deprecated `asyncio.get_event_loop()` calls that break on 3.14).

## Changes

### `pyproject.toml`
- `apscheduler==3.11.2` → `apscheduler==4.0.0a6`

### `utils/scheduler.py`
- Replace `AsyncIOScheduler` with `AsyncScheduler`
- `schedule_tasks` is now `async`, uses `await scheduler.add_schedule(fn, IntervalTrigger(...))`
- New `async clear_schedules(scheduler)` function replaces manual `pause()`/`get_jobs()`/`remove()` pattern
- Module-level `scheduler = AsyncScheduler()` (used as async context manager in `main.py`)

### `tasks.py`
- All task functions are now `async`
- Use `await scheduler.add_schedule(fn, IntervalTrigger(seconds=N))` instead of `scheduler.add_job(fn, "interval", seconds=N)`
- Return type changed from `Job` to `Optional[str]` (schedule ID)
- Imports updated: `AsyncScheduler` + `IntervalTrigger` replace `BaseScheduler` / `Job`

### `main.py`
- New `async run_scheduler()` coroutine uses `async with scheduler:` context manager
- `init_scheduler()` / `shut_down_scheduler()` / `helper()` removed — no longer needed
- `asyncio.Runner` drives `run_scheduler()` directly

### `internals/update.py`
- `self_update_agent`: replace `scheduler.pause()` / `scheduler.get_jobs()` / `job.remove()` / `scheduler.resume()` with `await clear_schedules(scheduler)` + `await schedule_tasks(scheduler)`
- Remove stale `TYPE_CHECKING` import of `apscheduler.job.Job`

### Tests
- `tests/utils.py/test_scheduler.py`: async tests, `AsyncScheduler`, `AsyncMock`
- `tests/internals/test_update.py`: mock `clear_schedules`/`schedule_tasks` as `AsyncMock` instead of `scheduler.pause`/`resume`
- `tests/test_main.py`: patch `run_scheduler` instead of `helper`/`shut_down_scheduler`/`scheduler`

## Test results

```
247 passed in 4.54s
```