### PR TITLE
build(deps-dev): update development dependencies across multiple projects

### DIFF
--- a/fake-sbatch/pyproject.toml
+++ b/fake-sbatch/pyproject.toml
@@ -17,7 +17,17 @@ dynamic = ["version"]
 fake-sbatch = "fake_sbatch.main:app"
 
 [dependency-groups]
-dev = ["pytest-mock>=3.15.1"]
+dev = [
+    "pytest-mock>=3.15.1",
+    "mypy>=2.3.0",
+    "pytest-cov>=7.1.0",
+    "pytest-env>=1.1.3",
+    "pytest-mock>=3.15.1",
+    "pytest-random-order>=1.2.0",
+    "pytest>=8.4.1,<9",
+    "ruff>=0.15.21",
+    "towncrier>=24.11.0",
+]
 
 [tool.ruff]
 line-length = 120

--- a/jobbergate-agent/pyproject.toml
+++ b/jobbergate-agent/pyproject.toml
@@ -51,7 +51,21 @@ Repository = "https://github.com/omnivector-solutions/jobbergate"
 Changelog = "https://github.com/omnivector-solutions/jobbergate/blob/main/jobbergate-agent/CHANGELOG.rst"
 
 [dependency-groups]
-dev = []
+dev = [
+    "faker>=40.31.0",
+    "mypy>=2.3.0",
+    "polyfactory>=3.3.0",
+    "pytest-asyncio>=1.4.0,<2",
+    "pytest-cov>=7.1.0",
+    "pytest-env>=1.1.3",
+    "pytest-mock>=3.15.1",
+    "pytest-random-order>=1.2.0",
+    "pytest>=8.4.1,<9",
+    "requests-mock>=1.12.1",
+    "respx>=0.23.1",
+    "ruff>=0.15.21",
+    "towncrier>=24.11.0",
+]
 
 [tool.uv.sources]
 jobbergate-core = { workspace = true }

--- a/jobbergate-api/pyproject.toml
+++ b/jobbergate-api/pyproject.toml
@@ -59,15 +59,28 @@ Changelog = "https://github.com/omnivector-solutions/jobbergate/blob/main/jobber
 [dependency-groups]
 dev = [
     "asgi-lifespan>=1.0.1",
+    "faker>=40.31.0",
+    "flaky>=3.8.1",
+    "mypy>=2.3.0",
     "nest-asyncio>=1.6.0",
     "pgcli>=4.3.0",
+    "polyfactory>=3.3.0",
     "psycopg2-binary>=2.9.11",
+    "pytest-asyncio>=1.4.0,<2",
+    "pytest-cov>=7.1.0",
+    "pytest-env>=1.1.3",
+    "pytest-mock>=3.15.1",
+    "pytest-random-order>=1.2.0",
+    "pytest>=8.4.1,<9",
+    "requests-mock>=1.12.1",
     "requests>=2.32.5",
+    "respx>=0.23.1",
+    "ruff>=0.15.21",
+    "towncrier>=24.11.0",
     "typer>=0.20.0",
     "types-aioboto3[essential]>=15.5.0",
     "types-pyyaml>=6.0",
     "types-toml>=0.10.8.7",
-    "flaky>=3.8.1",
 ]
 
 

--- a/jobbergate-cli/pyproject.toml
+++ b/jobbergate-cli/pyproject.toml
@@ -39,7 +39,23 @@ Repository = "https://github.com/omnivector-solutions/jobbergate"
 Changelog = "https://github.com/omnivector-solutions/jobbergate/blob/main/jobbergate-cli/CHANGELOG.rst"
 
 [dependency-groups]
-dev = ["plummet[time-machine]>=1.2.1", "types-pyyaml>=6.0.12"]
+dev = [
+    "faker>=40.31.0",
+    "mypy>=2.3.0",
+    "plummet[time-machine]>=1.2.1",
+    "polyfactory>=3.3.0",
+    "pytest-asyncio>=1.4.0,<2",
+    "pytest-cov>=7.1.0",
+    "pytest-env>=1.1.3",
+    "pytest-mock>=3.15.1",
+    "pytest-random-order>=1.2.0",
+    "pytest>=8.4.1,<9",
+    "requests-mock>=1.12.1",
+    "respx>=0.23.1",
+    "ruff>=0.15.21",
+    "towncrier>=24.11.0",
+    "types-pyyaml>=6.0.12",
+]
 
 [tool.uv.sources]
 jobbergate-core = { workspace = true }

--- a/jobbergate-core/pyproject.toml
+++ b/jobbergate-core/pyproject.toml
@@ -30,7 +30,21 @@ Repository = "https://github.com/omnivector-solutions/jobbergate"
 Changelog = "https://github.com/omnivector-solutions/jobbergate/blob/main/jobbergate-core/CHANGELOG.rst"
 
 [dependency-groups]
-dev = []
+dev = [
+    "faker>=40.31.0",
+    "mypy>=2.3.0",
+    "polyfactory>=3.3.0",
+    "pytest-asyncio>=1.4.0,<2",
+    "pytest-cov>=7.1.0",
+    "pytest-env>=1.1.3",
+    "pytest-mock>=3.15.1",
+    "pytest-random-order>=1.2.0",
+    "pytest>=8.4.1,<9",
+    "requests-mock>=1.12.1",
+    "respx>=0.23.1",
+    "ruff>=0.15.21",
+    "towncrier>=24.11.0",
+]
 
 [tool.ruff]
 extend = "../ruff.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,17 +11,5 @@ members = [
 
 [dependency-groups]
 dev = [
-    "faker>=40.31.0",
-    "mypy>=2.3.0",
-    "polyfactory>=3.3.0",
-    "pytest-asyncio>=1.4.0,<2",
-    "pytest-cov>=7.1.0",
-    "pytest-env>=1.1.3",
-    "pytest-mock>=3.15.1",
-    "pytest-random-order>=1.2.0",
-    "pytest>=8.4.1,<9",
-    "requests-mock>=1.12.1",
-    "respx>=0.23.1",
-    "ruff>=0.15.21",
     "towncrier>=24.11.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -18,21 +18,7 @@ members = [
 ]
 
 [manifest.dependency-groups]
-dev = [
-    { name = "faker", specifier = ">=40.31.0" },
-    { name = "mypy", specifier = ">=2.3.0" },
-    { name = "polyfactory", specifier = ">=3.3.0" },
-    { name = "pytest", specifier = ">=8.4.1,<9" },
-    { name = "pytest-asyncio", specifier = ">=1.4.0,<2" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-env", specifier = ">=1.1.3" },
-    { name = "pytest-mock", specifier = ">=3.15.1" },
-    { name = "pytest-random-order", specifier = ">=1.2.0" },
-    { name = "requests-mock", specifier = ">=1.12.1" },
-    { name = "respx", specifier = ">=0.23.1" },
-    { name = "ruff", specifier = ">=0.15.21" },
-    { name = "towncrier", specifier = ">=24.11.0" },
-]
+dev = [{ name = "towncrier", specifier = ">=24.11.0" }]
 
 [[package]]
 name = "aio-pika"
@@ -867,7 +853,14 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-env" },
     { name = "pytest-mock" },
+    { name = "pytest-random-order" },
+    { name = "ruff" },
+    { name = "towncrier" },
 ]
 
 [package.metadata]
@@ -878,7 +871,16 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest-mock", specifier = ">=3.15.1" }]
+dev = [
+    { name = "mypy", specifier = ">=2.3.0" },
+    { name = "pytest", specifier = ">=8.4.1,<9" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-env", specifier = ">=1.1.3" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-random-order", specifier = ">=1.2.0" },
+    { name = "ruff", specifier = ">=0.15.21" },
+    { name = "towncrier", specifier = ">=24.11.0" },
+]
 
 [[package]]
 name = "faker"
@@ -1234,7 +1236,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "sys_platform == 'win32'" },
+    { name = "ansicon" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981, upload-time = "2024-07-31T22:39:18.854Z" }
 wheels = [
@@ -1270,6 +1272,23 @@ dependencies = [
     { name = "types-ldap3" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "faker" },
+    { name = "mypy" },
+    { name = "polyfactory" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-env" },
+    { name = "pytest-mock" },
+    { name = "pytest-random-order" },
+    { name = "requests-mock" },
+    { name = "respx" },
+    { name = "ruff" },
+    { name = "towncrier" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "apscheduler", specifier = "==3.11.3" },
@@ -1289,7 +1308,21 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [
+    { name = "faker", specifier = ">=40.31.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
+    { name = "polyfactory", specifier = ">=3.3.0" },
+    { name = "pytest", specifier = ">=8.4.1,<9" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0,<2" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-env", specifier = ">=1.1.3" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-random-order", specifier = ">=1.2.0" },
+    { name = "requests-mock", specifier = ">=1.12.1" },
+    { name = "respx", specifier = ">=0.23.1" },
+    { name = "ruff", specifier = ">=0.15.21" },
+    { name = "towncrier", specifier = ">=24.11.0" },
+]
 
 [[package]]
 name = "jobbergate-api"
@@ -1328,11 +1361,24 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
+    { name = "faker" },
     { name = "flaky" },
+    { name = "mypy" },
     { name = "nest-asyncio" },
     { name = "pgcli" },
+    { name = "polyfactory" },
     { name = "psycopg2-binary" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-env" },
+    { name = "pytest-mock" },
+    { name = "pytest-random-order" },
     { name = "requests" },
+    { name = "requests-mock" },
+    { name = "respx" },
+    { name = "ruff" },
+    { name = "towncrier" },
     { name = "typer" },
     { name = "types-aioboto3", extra = ["essential"] },
     { name = "types-pyyaml" },
@@ -1374,11 +1420,24 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=1.0.1" },
+    { name = "faker", specifier = ">=40.31.0" },
     { name = "flaky", specifier = ">=3.8.1" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "pgcli", specifier = ">=4.3.0" },
+    { name = "polyfactory", specifier = ">=3.3.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
+    { name = "pytest", specifier = ">=8.4.1,<9" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0,<2" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-env", specifier = ">=1.1.3" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-random-order", specifier = ">=1.2.0" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "requests-mock", specifier = ">=1.12.1" },
+    { name = "respx", specifier = ">=0.23.1" },
+    { name = "ruff", specifier = ">=0.15.21" },
+    { name = "towncrier", specifier = ">=24.11.0" },
     { name = "typer", specifier = ">=0.20.0" },
     { name = "types-aioboto3", extras = ["essential"], specifier = ">=15.5.0" },
     { name = "types-pyyaml", specifier = ">=6.0" },
@@ -1405,7 +1464,20 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "faker" },
+    { name = "mypy" },
     { name = "plummet", extra = ["time-machine"] },
+    { name = "polyfactory" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-env" },
+    { name = "pytest-mock" },
+    { name = "pytest-random-order" },
+    { name = "requests-mock" },
+    { name = "respx" },
+    { name = "ruff" },
+    { name = "towncrier" },
     { name = "types-pyyaml" },
 ]
 
@@ -1427,7 +1499,20 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "faker", specifier = ">=40.31.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "plummet", extras = ["time-machine"], specifier = ">=1.2.1" },
+    { name = "polyfactory", specifier = ">=3.3.0" },
+    { name = "pytest", specifier = ">=8.4.1,<9" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0,<2" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-env", specifier = ">=1.1.3" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-random-order", specifier = ">=1.2.0" },
+    { name = "requests-mock", specifier = ">=1.12.1" },
+    { name = "respx", specifier = ">=0.23.1" },
+    { name = "ruff", specifier = ">=0.15.21" },
+    { name = "towncrier", specifier = ">=24.11.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]
 
@@ -1443,6 +1528,23 @@ dependencies = [
     { name = "python-jose" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "faker" },
+    { name = "mypy" },
+    { name = "polyfactory" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-env" },
+    { name = "pytest-mock" },
+    { name = "pytest-random-order" },
+    { name = "requests-mock" },
+    { name = "respx" },
+    { name = "ruff" },
+    { name = "towncrier" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<1" },
@@ -1454,7 +1556,21 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [
+    { name = "faker", specifier = ">=40.31.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
+    { name = "polyfactory", specifier = ">=3.3.0" },
+    { name = "pytest", specifier = ">=8.4.1,<9" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0,<2" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-env", specifier = ">=1.1.3" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-random-order", specifier = ">=1.2.0" },
+    { name = "requests-mock", specifier = ">=1.12.1" },
+    { name = "respx", specifier = ">=0.23.1" },
+    { name = "ruff", specifier = ">=0.15.21" },
+    { name = "towncrier", specifier = ">=24.11.0" },
+]
 
 [[package]]
 name = "jobbergate-documentation"


### PR DESCRIPTION
Shared dependencies on the root of the workspace worked for some time, but it looks like it was not intended by `uv` and it broke on latest release **0.12**. So we are now setting them per project.

https://github.com/astral-sh/uv/issues/7487